### PR TITLE
Switched to Debian Jessie as a base container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-alpine
+FROM python:3.6-jessie
 
 WORKDIR /app/woeip
 
@@ -6,16 +6,14 @@ ENV DJANGO_SETTINGS_MODULE woeip.settings
 ENV PIPENV_DONT_USE_PYENV 1
 ENV PIPENV_SYSTEM 1
 
-RUN apk add --update \
-    coreutils \
-    gcc \
-    libffi-dev \
-    make \
-    musl-dev \
-    postgresql-dev \
-    python3-dev \
-  && pip install pipenv \
-  && rm -rf /var/cache/apk/*
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y \
+        build-essential \
+        gettext \
+        libffi-dev \
+        libssl-dev \
+    && rm -rf /var/lib/apt/lists/* \
+    && pip install pipenv
 
 COPY Makefile /app/woeip
 COPY Pipfile /app/woeip

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ docker.pull: ## Pull the Docker containers
 	docker-compose -f docker-compose.yml -f docker-compose.$*.yml restart
 
 %.shell: ## Open a shell into the (local|production) app Docker container
-	docker-compose -f docker-compose.yml -f docker-compose.$*.yml exec app /bin/ash
+	docker-compose -f docker-compose.yml -f docker-compose.$*.yml exec app /bin/bash
 
 %.up: ## Start the (local|production) Docker containers
 	docker-compose -f docker-compose.yml -f docker-compose.$*.yml up -d


### PR DESCRIPTION
Alpine builds break too frequently. While the image size may be smaller, the inconvenience is not worth the benefit.