### PR TITLE
Added support for PostGIS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: required
-
 services:
   - docker
 
@@ -13,12 +11,11 @@ cache: pip
 install:
   - bash .travis/install_terraform.sh
   - make docker.build
-  - make local.up
 
 script:
-  - docker exec -t woeip.app make quality
-  - docker exec -t woeip.app make static
-  - docker exec -t woeip.app make test
+  - docker-compose -f docker-compose.yml -f docker-compose.travis.yml run app "make quality"
+  - docker-compose -f docker-compose.yml -f docker-compose.travis.yml run app "make static"
+  - docker-compose -f docker-compose.yml -f docker-compose.travis.yml run app "make test"
   - make validate_terraform
 
 after_success:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-alpine
+FROM python:3.6-jessie
 
 WORKDIR /app/woeip
 
@@ -6,16 +6,14 @@ ENV DJANGO_SETTINGS_MODULE woeip.settings
 ENV PIPENV_DONT_USE_PYENV 1
 ENV PIPENV_SYSTEM 1
 
-RUN apk add --update \
-    coreutils \
-    gcc \
-    libffi-dev \
-    make \
-    musl-dev \
-    postgresql-dev \
-    python3-dev \
-  && pip install pipenv \
-  && rm -rf /var/cache/apk/*
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y \
+        build-essential \
+        gettext \
+        libffi-dev \
+        libssl-dev \
+    && rm -rf /var/lib/apt/lists/* \
+    && pip install pipenv
 
 COPY Makefile /app/woeip
 COPY Pipfile /app/woeip

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && \
         build-essential \
         gettext \
         libffi-dev \
+        libgdal-dev \
         libssl-dev \
     && rm -rf /var/lib/apt/lists/* \
     && pip install pipenv

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ docker.pull: ## Pull the Docker containers
 	docker-compose -f docker-compose.yml -f docker-compose.$*.yml restart
 
 %.shell: ## Open a shell into the (local|production) app Docker container
-	docker-compose -f docker-compose.yml -f docker-compose.$*.yml exec app /bin/ash
+	docker-compose -f docker-compose.yml -f docker-compose.$*.yml exec app /bin/bash
 
 %.up: ## Start the (local|production) Docker containers
 	docker-compose -f docker-compose.yml -f docker-compose.$*.yml up -d

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ production-requirements: ## Install requirements for production
 	pipenv install
 
 test: clean ## Run tests and generate coverage report
-	SECRET_KEY=fake DATABASE_URL="sqlite://:memory:" coverage run -m pytest --durations=25 -v
+	coverage run -m pytest --durations=25 -v
 	coverage report -m
 
 quality: ## Run pep8 and Pylint

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -20,7 +20,7 @@ services:
     environment:
       - DEBUG=true
       - SECRET_KEY=replace-me
-      - DATABASE_URL=psql://postgres:postgres@woeip.db:5432/woeip?connect_timeout=60
+      - DATABASE_URL=postgis://postgres:postgres@woeip.db:5432/woeip?connect_timeout=60
     links:
       - db
     ports:

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -17,12 +17,12 @@ services:
   app:
     # Instruct Gunicorn to reload code when it is changed locally.
     command: --reload
-    links:
-      - db
     environment:
       - DEBUG=true
       - SECRET_KEY=replace-me
       - DATABASE_URL=psql://postgres:postgres@woeip.db:5432/woeip?connect_timeout=60
+    links:
+      - db
     ports:
       # This port is primarily exposed for debugging. Use the web service's port to properly access the service.
       - 8000:8000

--- a/docker-compose.travis.yml
+++ b/docker-compose.travis.yml
@@ -1,0 +1,20 @@
+version: "3"
+services:
+  db:
+    container_name: woeip.db
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_DB=woeip
+    image: postgres:11.1-alpine
+  app:
+    # NOTE: A command should be passed to the container via docker-compose run. This ensures we don't start
+    # gunicorn unnecessarily, and run out of memory.
+    entrypoint:
+      - bash
+      - -c
+    environment:
+      - SECRET_KEY=replace-me
+      - DATABASE_URL=postgres://postgres:postgres@woeip.db:5432/woeip?connect_timeout=60
+    links:
+      - db

--- a/docker-compose.travis.yml
+++ b/docker-compose.travis.yml
@@ -6,7 +6,7 @@ services:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
       - POSTGRES_DB=woeip
-    image: postgres:11.1-alpine
+    image: mdillon/postgis:11
   app:
     # NOTE: A command should be passed to the container via docker-compose run. This ensures we don't start
     # gunicorn unnecessarily, and run out of memory.
@@ -15,6 +15,6 @@ services:
       - -c
     environment:
       - SECRET_KEY=replace-me
-      - DATABASE_URL=postgres://postgres:postgres@woeip.db:5432/woeip?connect_timeout=60
+      - DATABASE_URL=postgis://postgres:postgres@woeip.db:5432/woeip?connect_timeout=60
     links:
       - db

--- a/woeip/settings.py
+++ b/woeip/settings.py
@@ -26,6 +26,7 @@ DJANGO_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'django.contrib.flatpages',
+    'django.contrib.gis',
 ]
 
 THIRD_PARTY_APPS = [


### PR DESCRIPTION
This is a redux of #5 and #6. The primary difference is the first commit, which updates the Travis build.

The Travis build was previously failing, with processes exiting with code 137. This exit code usually indicates the process was killed because the system ran out of memory. Since the processes were running in the `app` container, the only other process that would kill the memory is `gunicorn`.

That process is no longer run on Travis. Instead we restart the containers for every step of the build script, each time running only the process necessary to complete that part of the script.