### PR TITLE
Refactor dustrak load and join functions

### DIFF
--- a/woeip/apps/air_quality/dustrak.py
+++ b/woeip/apps/air_quality/dustrak.py
@@ -127,7 +127,7 @@ def load_dustrak(file_handle, tz):
 
     Parameters
     ----------
-    file_handle : str
+    file_handle : file handle, mode='rb'
 
     Returns
     -------
@@ -167,7 +167,7 @@ def load_gps(file_handle):
 
     Parameters
     ----------
-    file_handle : file stream
+    file_handle : file handle, mode='rb'
 
     Returns
     -------
@@ -223,8 +223,8 @@ def join(dustrak_file_handle, gps_file_handle, tz='America/Los_Angeles', toleran
 
     Parameters
     ----------
-    dustrak_file_handle : file handle
-    gps_file_handle : file handle
+    dustrak_file_handle : file handle, mode='rb'
+    gps_file_handle : file handle, mode='rb'
     tz : str
     tolerance : numeric
         How far away (in seconds) can a air quality measurement be from a GPS measurement to be

--- a/woeip/apps/air_quality/dustrak.py
+++ b/woeip/apps/air_quality/dustrak.py
@@ -26,10 +26,10 @@ def parse_header(f):
     """
     header = {}
 
-    lines = itertools.takewhile(lambda x: x not in (b'\n', b'\r', b'\r\n'), f)
+    lines = itertools.takewhile(lambda x: x not in ('\n', '\r', '\r\n'), f)
     for line in lines:
-        line = line.rstrip(b'\n\r')
-        key, value = line.split(b',')
+        line = line.rstrip('\n\r')
+        key, value = line.split(',')
         header[key] = value
 
     return header
@@ -127,7 +127,7 @@ def load_dustrak(file_handle, tz):
 
     Parameters
     ----------
-    file_handle : file handle, mode='rb'
+    file_handle : file handle
 
     Returns
     -------
@@ -139,17 +139,16 @@ def load_dustrak(file_handle, tz):
     if data.columns[0] != 'Elapsed Time [s]':
         raise ValueError('First column must be elapsed time in seconds')
 
-    start_time = b' '.join([header[b'Test Start Date'],
-                            header[b'Test Start Time']])
-    start_time = datetime.datetime.strptime(start_time.decode('utf-8'),
-                                            '%m/%d/%Y %I:%M:%S %p')
+    start_time = ' '.join([header['Test Start Date'],
+                           header['Test Start Time']])
+    start_time = datetime.datetime.strptime(start_time, '%m/%d/%Y %I:%M:%S %p')
 
     local_timezone = pytz.timezone(tz)
     start_time = local_timezone.localize(start_time)
     start_time = start_time.astimezone(pytz.timezone('UTC'))
 
-    sample_interval_minutes = header[b'Test Interval [M:S]'].split(b':')[0]
-    if sample_interval_minutes != b'0':
+    sample_interval_minutes = header['Test Interval [M:S]'].split(':')[0]
+    if sample_interval_minutes != '0':
         raise NotImplementedError('Minute sampling intervals not supported')
 
     sample_offsets = np.array(data['Elapsed Time [s]'], dtype='timedelta64[s]')
@@ -167,7 +166,7 @@ def load_gps(file_handle):
 
     Parameters
     ----------
-    file_handle : file handle, mode='rb'
+    file_handle : file handle
 
     Returns
     -------
@@ -175,7 +174,6 @@ def load_gps(file_handle):
     """
     gps = []
     for sample in file_handle:
-        sample = sample.decode('utf-8')
         if sample.startswith('$GPRMC'):
             gps_sample = parse_gps_sentence(sample)
             gps_dict = sentence_to_dict(gps_sample)
@@ -223,8 +221,8 @@ def join(dustrak_file_handle, gps_file_handle, tz='America/Los_Angeles', toleran
 
     Parameters
     ----------
-    dustrak_file_handle : file handle, mode='rb'
-    gps_file_handle : file handle, mode='rb'
+    dustrak_file_handle : file handle
+    gps_file_handle : file handle
     tz : str
     tolerance : numeric
         How far away (in seconds) can a air quality measurement be from a GPS measurement to be

--- a/woeip/apps/air_quality/dustrak.py
+++ b/woeip/apps/air_quality/dustrak.py
@@ -26,10 +26,10 @@ def parse_header(f):
     """
     header = {}
 
-    lines = itertools.takewhile(lambda x: x != '\n', f)
+    lines = itertools.takewhile(lambda x: x not in (b'\n', b'\r', b'\r\n'), f)
     for line in lines:
-        line = line.rstrip('\n')
-        key, value = line.split(',')
+        line = line.rstrip(b'\n\r')
+        key, value = line.split(b',')
         header[key] = value
 
     return header
@@ -139,17 +139,17 @@ def load_dustrak(file_handle, tz):
     if data.columns[0] != 'Elapsed Time [s]':
         raise ValueError('First column must be elapsed time in seconds')
 
-    start_time = ' '.join([header['Test Start Date'],
-                           header['Test Start Time']])
-    start_time = datetime.datetime.strptime(start_time,
+    start_time = b' '.join([header[b'Test Start Date'],
+                            header[b'Test Start Time']])
+    start_time = datetime.datetime.strptime(start_time.decode('utf-8'),
                                             '%m/%d/%Y %I:%M:%S %p')
 
     local_timezone = pytz.timezone(tz)
     start_time = local_timezone.localize(start_time)
     start_time = start_time.astimezone(pytz.timezone('UTC'))
 
-    sample_interval_minutes = header['Test Interval [M:S]'].split(':')[0]
-    if sample_interval_minutes != '0':
+    sample_interval_minutes = header[b'Test Interval [M:S]'].split(b':')[0]
+    if sample_interval_minutes != b'0':
         raise NotImplementedError('Minute sampling intervals not supported')
 
     sample_offsets = np.array(data['Elapsed Time [s]'], dtype='timedelta64[s]')
@@ -175,6 +175,7 @@ def load_gps(file_handle):
     """
     gps = []
     for sample in file_handle:
+        sample = sample.decode('utf-8')
         if sample.startswith('$GPRMC'):
             gps_sample = parse_gps_sentence(sample)
             gps_dict = sentence_to_dict(gps_sample)
@@ -233,8 +234,17 @@ def join(dustrak_file_handle, gps_file_handle, tz='America/Los_Angeles', toleran
     -------
     A pandas DataFrame containing the sample time (in UTC), latitude, longitude, and measurement
     """
-    data = load_dustrak(dustrak_file_handle, tz)
-    gps = load_gps(gps_file_handle)
+    dustrak_file_handle.seek(0)
+    gps_file_handle.seek(0)
+    try:
+        data = load_dustrak(dustrak_file_handle, tz)
+    except Exception as e:
+        raise ValueError(f"Dustrak file format not recognized. {e}")
+
+    try:
+        gps = load_gps(gps_file_handle)
+    except Exception as e:
+        raise ValueError(f"GPS file format not recognized. {e}")
 
     joined_data = pd.merge_asof(data, gps, on='time', direction='nearest',
                                 tolerance=pd.Timedelta(f'{tolerance}s'))

--- a/woeip/apps/air_quality/tests/test_dustrak.py
+++ b/woeip/apps/air_quality/tests/test_dustrak.py
@@ -25,14 +25,16 @@ target_data = get_target_data()
 
 def test_joiner():
     """Test the output of the function that joins GPS and air quality measurements based on time stamps"""
-    dustrak_file_handle = open(test_data_directory / 'dustrak.csv', 'r')
-    gps_file_handle = open(test_data_directory / 'gps.log', 'r')
+    with open(test_data_directory / 'dustrak.csv', 'r') as f:
+        contents = f.read()
+    _, air_quality = dustrak.load_dustrak(contents, tz='America/Los_Angeles')
+
+    with open(test_data_directory / 'gps.log', 'r') as f:
+        contents = f.read()
+    gps = dustrak.load_gps(contents)
 
     with pytest.warns(UserWarning):
-        joined_data = dustrak.join(dustrak_file_handle, gps_file_handle)
-
-    dustrak_file_handle.close()
-    gps_file_handle.close()
+        joined_data = dustrak.join(air_quality, gps)
 
     for column in target_data:
         if column == 'time':

--- a/woeip/apps/air_quality/tests/test_dustrak.py
+++ b/woeip/apps/air_quality/tests/test_dustrak.py
@@ -25,8 +25,8 @@ target_data = get_target_data()
 
 def test_joiner():
     """Test the output of the function that joins GPS and air quality measurements based on time stamps"""
-    dustrak_file_handle = open(test_data_directory / 'dustrak.csv', 'rb')
-    gps_file_handle = open(test_data_directory / 'gps.log', 'rb')
+    dustrak_file_handle = open(test_data_directory / 'dustrak.csv', 'r')
+    gps_file_handle = open(test_data_directory / 'gps.log', 'r')
 
     with pytest.warns(UserWarning):
         joined_data = dustrak.join(dustrak_file_handle, gps_file_handle)

--- a/woeip/apps/air_quality/tests/test_dustrak.py
+++ b/woeip/apps/air_quality/tests/test_dustrak.py
@@ -25,8 +25,8 @@ target_data = get_target_data()
 
 def test_joiner():
     """Test the output of the function that joins GPS and air quality measurements based on time stamps"""
-    dustrak_file_handle = open(test_data_directory / 'dustrak.csv', 'r')
-    gps_file_handle = open(test_data_directory / 'gps.log', 'r')
+    dustrak_file_handle = open(test_data_directory / 'dustrak.csv', 'rb')
+    gps_file_handle = open(test_data_directory / 'gps.log', 'rb')
 
     with pytest.warns(UserWarning):
         joined_data = dustrak.join(dustrak_file_handle, gps_file_handle)


### PR DESCRIPTION
A few changes to the dustrak loader and joiner. Most importantly, raise ``ValueError`` when air quality or gps files do not load. Return the error message that the loader raised. Also, open the files in binary mode and catch multiple different kinds of line endings when parsing the header.

