### PR TITLE
Use current versions of dustrak and gps loaders in upload view

### DIFF
--- a/woeip/apps/air_quality/dustrak.py
+++ b/woeip/apps/air_quality/dustrak.py
@@ -117,6 +117,7 @@ def load_dustrak(contents, tz):
     header = {}
     lines = itertools.takewhile(lambda x: x != '\r\n', contents)
     for line in lines:
+        print(line)
         line = line.rstrip('\r\n')
         key, value = line.split(',')
         header[key] = value

--- a/woeip/apps/air_quality/dustrak.py
+++ b/woeip/apps/air_quality/dustrak.py
@@ -115,9 +115,9 @@ def load_dustrak(contents, tz):
     contents = io.StringIO(contents)
 
     header = {}
-    lines = itertools.takewhile(lambda x: x != '\n', contents)
+    lines = itertools.takewhile(lambda x: x != '\r\n', contents)
     for line in lines:
-        line = line.rstrip('\n')
+        line = line.rstrip('\r\n')
         key, value = line.split(',')
         header[key] = value
 

--- a/woeip/apps/air_quality/tests/test_dustrak.py
+++ b/woeip/apps/air_quality/tests/test_dustrak.py
@@ -25,12 +25,12 @@ target_data = get_target_data()
 
 def test_joiner():
     """Test the output of the function that joins GPS and air quality measurements based on time stamps"""
-    with open(test_data_directory / 'dustrak.csv', 'r') as f:
-        contents = f.read()
+    with open(test_data_directory / 'dustrak.csv', 'rb') as f:
+        contents = f.read().decode('utf-8')
     _, air_quality = dustrak.load_dustrak(contents, tz='America/Los_Angeles')
 
-    with open(test_data_directory / 'gps.log', 'r') as f:
-        contents = f.read()
+    with open(test_data_directory / 'gps.log', 'rb') as f:
+        contents = f.read().decode('utf-8')
     gps = dustrak.load_gps(contents)
 
     with pytest.warns(UserWarning):

--- a/woeip/apps/air_quality/views.py
+++ b/woeip/apps/air_quality/views.py
@@ -49,16 +49,22 @@ def upload(request):
                                          session=form.instance,
                                          uploaded_by=request.user)
 
-                joined_data = dustrak.join(request.FILES['air_quality'].file,
-                                           request.FILES['gps'].file)
+                air_quality_contents = request.FILES['air_quality'].read().decode('utf-8')
+                _, air_quality_data = dustrak.load_dustrak(air_quality_contents, 'America/Los_Angeles')
+
+                gps_contents = request.FILES['gps'].read().decode('utf-8')
+                gps_data = dustrak.load_gps(gps_contents)
+                joined_data = dustrak.join(air_quality_data, gps_data)
+
             # TODO: Research possible exceptions. Send specific error messages
             except Exception as e:
                 messages.add_message(request, messages.ERROR, f'File upload failed, error: {e}')
                 return redirect('upload')
 
+            form.save()
             air_quality.save()
             gps.save()
-            dustrak.save(joined_data, air_quality)
+            dustrak.save(joined_data, form.instance)
 
             messages.add_message(request, messages.SUCCESS, 'Files successfully uploaded')
             return redirect('upload')

--- a/woeip/apps/air_quality/views.py
+++ b/woeip/apps/air_quality/views.py
@@ -6,6 +6,7 @@ from django.contrib import messages
 from django.contrib.auth import authenticate, login
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import redirect, render
+from django.utils.encoding import force_text
 
 from woeip.apps.air_quality import dustrak, forms, models
 from woeip.apps.core.models import User
@@ -49,10 +50,10 @@ def upload(request):
                                          session=form.instance,
                                          uploaded_by=request.user)
 
-                air_quality_contents = request.FILES['air_quality'].read().decode('utf-8')
+                air_quality_contents = force_text(request.FILES['air_quality'].read())
                 _, air_quality_data = dustrak.load_dustrak(air_quality_contents, 'America/Los_Angeles')
 
-                gps_contents = request.FILES['gps'].read().decode('utf-8')
+                gps_contents = force_text(request.FILES['gps'].read())
                 gps_data = dustrak.load_gps(gps_contents)
                 joined_data = dustrak.join(air_quality_data, gps_data)
 


### PR DESCRIPTION
Prior to this change, file upload does not work.
 - Detect ``\r\n`` line endings in the raw data txt files
 - Dustrak and gps loaders want strings, not file handles
 - ``dustrak.save`` wants a ``Session`` instance, not ``SessionData`` reflecting changes since #26 

I fixed this in some other branch, but somehow it got lost, so reapplying here.