### PR TITLE
Using latest version of Debian as Docker base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-jessie
+FROM python:3.6
 
 WORKDIR /app/woeip
 


### PR DESCRIPTION
Jessie is EOL. Rather than pinning to a specific version of Debian, we will use the latest version. None of our code is OS-dependent, so this should not be an issue.

Fixes #77