### PR TITLE
Expose collection sequence in an API call

### DIFF
--- a/api/woeip/apps/air_quality/serializers.py
+++ b/api/woeip/apps/air_quality/serializers.py
@@ -81,6 +81,10 @@ class CollectionGeoSerializer(serializers.Serializer):
     pollutant_values = serializers.ListField(child=PollutantValueSerializer())
 
 
+class CollectionSequenceSerializer(serializers.Serializer):
+    sequence = serializers.IntegerField()
+
+
 class SensorSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = Sensor

--- a/api/woeip/apps/air_quality/tests/test_api.py
+++ b/api/woeip/apps/air_quality/tests/test_api.py
@@ -21,7 +21,7 @@ class WoaqAPITestCase(APITestCase):
 
         self.logger = logging.getLogger('django.request')
         self._original_logger_level = self.logger.getEffectiveLevel()
-        self.logger.setLevel(logging.DEBUG)
+        self.logger.setLevel(logging.ERROR)
 
     def tearDown(self):
         shutil.rmtree(self._temp_media, ignore_errors=True)

--- a/api/woeip/apps/air_quality/views.py
+++ b/api/woeip/apps/air_quality/views.py
@@ -45,7 +45,7 @@ class CollectionViewSet(viewsets.ModelViewSet):
         serializer.save()
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 
-    @action(methods=['get'], detail=True)
+    @action(detail=True, methods=["GET"])
     def sequence(self, request, pk, *args, **kwargs):
         collection = get_object_or_404(self.queryset, pk=pk)
         sequence = collection.get_sequence()

--- a/api/woeip/apps/air_quality/views.py
+++ b/api/woeip/apps/air_quality/views.py
@@ -45,6 +45,14 @@ class CollectionViewSet(viewsets.ModelViewSet):
         serializer.save()
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 
+    @action(methods=['get'], detail=True)
+    def sequence(self, request, pk, *args, **kwargs):
+        collection = get_object_or_404(self.queryset, pk=pk)
+        sequence = collection.get_sequence()
+        serializer = serializers.CollectionSequenceSerializer(
+            {"sequence": sequence})
+        return Response(serializer.data)
+
 
 class CollectionFileViewSet(viewsets.ModelViewSet):
     queryset = models.CollectionFile.objects.all()


### PR DESCRIPTION
---
name: Expose collection sequence in an API call
about: Request merging changes into the code base
labels: backend, api, MVP
reviewers: @r-b-g-b, @ifed3

---

## Checklist
- [x] Add description
- [x] Reference open issue pull request addresses
- [x] Pass functional tests
  - complete on the local machine with `make local.shell` `make test`
- [x] Request code review
  - Please allow **36 hours** from opening a pull request before merging a pull request- even if it has already recieved an approving review.
- [x] Address comments on code and resolve requested changes
- [ ] Merge own code

## Description
Issue: https://github.com/openoakland/woeip/issues/136

Exposes `Collection` model method `get_sequence()` in a `/collections/<id>/sequence` API call.