### PR TITLE
Fixes duplicate collection creation described in #153

### DIFF
--- a/api/woeip/apps/air_quality/serializers.py
+++ b/api/woeip/apps/air_quality/serializers.py
@@ -65,6 +65,7 @@ class CollectionSerializer(serializers.HyperlinkedModelSerializer):
             starts_at=validated_data.get("starts_at"),
             ends_at=validated_data.get("ends_at"),
         )
+        collection.save()
 
         for upload_file in validated_data.pop("upload_files", []):
             collection_file = CollectionFile.objects.create(
@@ -73,7 +74,7 @@ class CollectionSerializer(serializers.HyperlinkedModelSerializer):
             collection_file.file.save(
                 upload_file["file_name"], ContentFile(upload_file["file_data"]))
 
-        return super().create(validated_data)
+        return collection
 
 
 class CollectionGeoSerializer(serializers.Serializer):

--- a/api/woeip/apps/air_quality/serializers.py
+++ b/api/woeip/apps/air_quality/serializers.py
@@ -65,7 +65,6 @@ class CollectionSerializer(serializers.HyperlinkedModelSerializer):
             starts_at=validated_data.get("starts_at"),
             ends_at=validated_data.get("ends_at"),
         )
-        collection.save()
 
         for upload_file in validated_data.pop("upload_files", []):
             collection_file = CollectionFile.objects.create(

--- a/api/woeip/apps/air_quality/views.py
+++ b/api/woeip/apps/air_quality/views.py
@@ -1,6 +1,7 @@
 # pylint: disable=too-many-ancestors
 import logging
 
+from django.db import transaction
 from django.shortcuts import get_object_or_404
 from rest_framework import status
 from rest_framework import viewsets
@@ -39,6 +40,7 @@ class CollectionViewSet(viewsets.ModelViewSet):
 
         return Response(serializer.data)
 
+    @transaction.atomic
     def create(self, request, *args, **kwargs):
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)


### PR DESCRIPTION
---
name: Fix for https://github.com/openoakland/woeip/issues/153
about: Fixes duplicate collection creation
labels: bugfix, backend
reviewers: @r-b-g-b

---

## Checklist
- [x] Add description
- [x] Reference open issue pull request addresses
- [x] Pass functional tests
  - complete on the local machine with `make local.shell` `make test`
- [x] Request code review
  - Please allow **36 hours** from opening a pull request before merging a pull request- even if it has already recieved an approving review.
- [ ] Address comments on code and resolve requested changes
- [ ] Merge own code

## Description
Issue: https://github.com/openoakland/woeip/issues/153

Removes call to `super.create()`, instead saves and returns a new collection object directly.