### PR TITLE
Autogenerated Swagger/ReDoc API Documentation

### DIFF
--- a/api/requirements.in/prod.txt
+++ b/api/requirements.in/prod.txt
@@ -6,6 +6,7 @@ django-extensions
 django-model-utils
 django-storages
 djangorestframework
+drf-yasg
 gevent
 gunicorn==19.9.0
 numpy

--- a/api/requirements/dev.txt
+++ b/api/requirements/dev.txt
@@ -9,7 +9,11 @@ astroid==2.2.5
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 boto==2.49.0              # via django-boto
+certifi==2019.9.11        # via requests
 cffi==1.12.3              # via argon2-cffi
+chardet==3.0.4            # via requests
+coreapi==2.3.3            # via drf-yasg
+coreschema==0.0.4         # via coreapi, drf-yasg
 coverage==4.5.3
 django-boto==0.3.12
 django-debug-toolbar==2.0
@@ -19,18 +23,24 @@ django-model-utils==3.2.0
 django-storages==1.7.1
 django==2.1.11
 djangorestframework==3.10.2
+drf-yasg==1.17.0
 factory-boy==2.12.0
 faker==2.0.0              # via factory-boy
 gevent==1.4.0
 greenlet==0.4.15          # via gevent
 gunicorn==19.9.0
+idna==2.8                 # via requests
 importlib-metadata==0.18  # via pluggy, pytest
+inflection==0.3.1         # via drf-yasg
+itypes==1.1.0             # via coreapi
+jinja2==2.10.3            # via coreschema
 lazy-object-proxy==1.4.1  # via astroid
+markupsafe==1.1.1         # via jinja2
 more-itertools==7.1.0     # via pytest
 mypy-extensions==0.4.1    # via mypy
 mypy==0.720
 numpy==1.16.4
-packaging==19.0           # via pytest
+packaging==19.0           # via drf-yasg, pytest
 pandas==0.24.2
 pluggy==0.12.0            # via pytest
 psycopg2-binary==2.8.3
@@ -42,11 +52,16 @@ pytest-django==3.5.1
 pytest==5.0.1             # via pytest-django
 python-dateutil==2.8.0    # via django-boto, faker, pandas
 pytz==2019.1              # via django, pandas
-six==1.12.0               # via argon2-cffi, astroid, django-extensions, faker, packaging, python-dateutil
+requests==2.22.0          # via coreapi
+ruamel.yaml.clib==0.2.0   # via ruamel.yaml
+ruamel.yaml==0.16.5       # via drf-yasg
+six==1.12.0               # via argon2-cffi, astroid, django-extensions, drf-yasg, faker, packaging, python-dateutil
 sqlparse==0.3.0           # via django-debug-toolbar
 text-unidecode==1.2       # via faker
 typed-ast==1.4.0          # via astroid, mypy
 typing-extensions==3.7.4  # via mypy
+uritemplate==3.0.0        # via coreapi, drf-yasg
+urllib3==1.25.7           # via requests
 wcwidth==0.1.7            # via pytest
 wrapt==1.11.2             # via astroid
 zipp==0.5.2               # via importlib-metadata

--- a/api/requirements/prod.txt
+++ b/api/requirements/prod.txt
@@ -6,7 +6,11 @@
 #
 argon2-cffi==19.1.0
 boto==2.49.0              # via django-boto
+certifi==2019.9.11        # via requests
 cffi==1.12.3              # via argon2-cffi
+chardet==3.0.4            # via requests
+coreapi==2.3.3            # via drf-yasg
+coreschema==0.0.4         # via coreapi, drf-yasg
 django-boto==0.3.12
 django-environ==0.4.5
 django-extensions==2.1.9
@@ -14,14 +18,27 @@ django-model-utils==3.2.0
 django-storages==1.7.1
 django==2.1.11
 djangorestframework==3.10.2
+drf-yasg==1.17.0
 gevent==1.4.0
 greenlet==0.4.15          # via gevent
 gunicorn==19.9.0
+idna==2.8                 # via requests
+inflection==0.3.1         # via drf-yasg
+itypes==1.1.0             # via coreapi
+jinja2==2.10.3            # via coreschema
+markupsafe==1.1.1         # via jinja2
 numpy==1.16.4
+packaging==19.2           # via drf-yasg
 pandas==0.24.2
 psycopg2-binary==2.8.3
 pycparser==2.19           # via cffi
 pynmea2==1.15.0
+pyparsing==2.4.5          # via packaging
 python-dateutil==2.8.0    # via django-boto, pandas
 pytz==2019.1              # via django, pandas
-six==1.12.0               # via argon2-cffi, django-extensions, python-dateutil
+requests==2.22.0          # via coreapi
+ruamel.yaml.clib==0.2.0   # via ruamel.yaml
+ruamel.yaml==0.16.5       # via drf-yasg
+six==1.12.0               # via argon2-cffi, django-extensions, drf-yasg, packaging, python-dateutil
+uritemplate==3.0.0        # via coreapi, drf-yasg
+urllib3==1.25.7           # via requests

--- a/api/woeip/settings.py
+++ b/api/woeip/settings.py
@@ -30,7 +30,7 @@ DJANGO_APPS = [
     "django.contrib.gis",
 ]
 
-THIRD_PARTY_APPS = ["django_extensions", "rest_framework", "storages"]
+THIRD_PARTY_APPS = ["django_extensions", "rest_framework", "storages", "drf_yasg"]
 
 LOCAL_APPS = ["woeip.apps.core", "woeip.apps.air_quality"]
 

--- a/api/woeip/swagger.py
+++ b/api/woeip/swagger.py
@@ -1,0 +1,39 @@
+from django.conf.urls import url
+from drf_yasg.views import get_schema_view
+from drf_yasg import openapi
+
+schema_view = get_schema_view(
+    openapi.Info(
+        title="West Oakland Air Quality API",
+        default_version="v1",
+        description=(
+            "West Oakland Air Quality (WOAQ) is a project of OpenOakland "
+            "focused on building digital advocacy tools around air quality data "
+            "collected by volunteers and citizen scientists. WOAQ works in partnership "
+            "with West Oakland Environmental Indicators Project (WOEIP). This API is "
+            "for storing and updating WOEIP air quality datasets."
+        ),
+        terms_of_service=None,  # Optional URL to terms of service
+        contact=openapi.Contact(email="woaq@openoakland.org"),
+        license=openapi.License(
+            name="MIT", url="https://github.com/openoakland/woeip/blob/master/LICENSE"
+        ),
+    ),
+    public=False,
+)
+
+urlpatterns = [
+    url(
+        r"^swagger(?P<format>\.json|\.yaml)$",
+        schema_view.without_ui(cache_timeout=0),
+        name="schema-json",
+    ),
+    url(
+        r"^swagger/$",
+        schema_view.with_ui("swagger", cache_timeout=0),
+        name="schema-swagger-ui",
+    ),
+    url(
+        r"^redoc/$", schema_view.with_ui("redoc", cache_timeout=0), name="schema-redoc",
+    ),
+]

--- a/api/woeip/urls.py
+++ b/api/woeip/urls.py
@@ -5,6 +5,7 @@ from rest_framework import routers
 
 from .apps.air_quality import views
 from .apps.core import views as core_views
+from .swagger import urlpatterns as swagger_urlpatterns
 
 router = routers.DefaultRouter(trailing_slash=False)
 router.register(r"calibrations", views.CalibrationViewSet)
@@ -23,3 +24,5 @@ urlpatterns = [
     path("admin/", admin.site.urls),
     path("api-auth/", include("rest_framework.urls", namespace="rest_framework")),
 ]
+
+urlpatterns += swagger_urlpatterns


### PR DESCRIPTION
---
name: Autogenerated Swagger/ReDoc API Documentation
about: Request merging changes into the code base
title: ''
labels: ''
reviewers: ''

---

## Checklist
- [X] Add description
- [X] Reference open issue pull request addresses
- [x] Pass functional tests
  - complete on the local machine with `make local.shell` `make test`
- [x] Request code review
  - Please allow **36 hours** from opening a pull request before merging a pull request- even if it has already recieved an approving review.
- [ ] Address comments on code and resolve requested changes
- [ ] Merge own code

## Description
Issue: Resolves #148 

This pull request adds drf-yasg, a Django REST Framework extension that automatically generates an OpenAPI schema and sets up Swagger and ReDoc views for it.

[OpenAPI](https://swagger.io/docs/specification/about/) is an API description standard for REST APIs. OpenAPI schema specifications are json objects with metadata about your schema.

Swagger and ReDoc are two popular UIs that use OpenAPI. They list all available APIs, documentation for what they do and accept, and have forms that let you hit them directly in the page. They both contain the same information and have similar functionality, but have different interface styles. 

The following endpoints are added by this PR:
- http://api.lvh.me/swagger.json -- this is the raw OpenAPI schema specification in json
- http://api.lvh.me/swagger/ -- this is the new Swagger UI
- http://api.lvh.me/redoc/ -- this is the new ReDoc UI