### PR TITLE
Generate mock data for development

### DIFF
--- a/api/woeip/apps/air_quality/management/commands/generate_data.py
+++ b/api/woeip/apps/air_quality/management/commands/generate_data.py
@@ -1,0 +1,62 @@
+import datetime
+from django.core.management.base import BaseCommand, CommandError
+
+from woeip.apps.air_quality.tests import factories
+
+
+class Command(BaseCommand):
+    help = "Generate mock air quality data."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--collections",
+            default=3,
+            type=int,
+            help="number of collections to generate",
+        )
+        parser.add_argument(
+            "--observations",
+            default=120,
+            type=int,
+            help="number of observations per collection to generate",
+        )
+        pass
+
+    def handle(self, *args, **options):
+        self.stdout.write(
+            f"Starting to generate {options['observations']} mock observations "
+            f"for {options['collections']} collections."
+        )
+
+        for i in range(options["collections"]):
+            collection_file = factories.CollectionFileFactory()
+            pollutant = factories.PollutantFactory()
+
+            # Create series of TimeGeo incrementing by 1 second
+            initial_time_geo = factories.TimeGeoFactory(collection_file=collection_file)
+            time_geo_series = [initial_time_geo] + [
+                factories.TimeGeoFactory(
+                    collection_file=collection_file,
+                    time=initial_time_geo.time + datetime.timedelta(seconds=j + 1),
+                )
+                for j in range(options["observations"] - 1)
+            ]
+
+            # Generate pollutant values for each TimeGeo
+            [
+                factories.PollutantValueFactory(
+                    collection_file=collection_file,
+                    pollutant=pollutant,
+                    time_geo=time_geo,
+                )
+                for time_geo in time_geo_series
+            ]
+
+            self.stdout.write(
+                f"Generated {len(time_geo_series)} observations "
+                f"for collection: {str(collection_file)}, pollutant: {str(pollutant)}."
+            )
+
+        self.stdout.write(
+            f"Done generating data for {options['collections']} collections."
+        )

--- a/api/woeip/apps/air_quality/tests/factories.py
+++ b/api/woeip/apps/air_quality/tests/factories.py
@@ -53,7 +53,7 @@ class PollutantFactory(factory.DjangoModelFactory):
     class Meta:
         model = models.Pollutant
 
-    name = factory.Faker("safe_color_name")
+    name = factory.Faker("random_element", elements=["PM1", "PM2.5", "PM4", "PM10"],)
     description = factory.Faker("sentence", nb_words=3)
 
 

--- a/api/woeip/apps/core/tests/factories.py
+++ b/api/woeip/apps/core/tests/factories.py
@@ -17,3 +17,4 @@ class UserFactory(factory.DjangoModelFactory):
 
     class Meta:
         model = User
+        django_get_or_create = ("username",)  # avoid username already exists error


### PR DESCRIPTION
## Checklist
- [X] Add description
- [X] Reference open issue pull request addresses
- [X] Pass functional tests
  - complete on the local machine with `make local.shell` `make test`
- [X] Request code review
  - Please allow **36 hours** from opening a pull request before merging a pull request- even if it has already recieved an approving review.
- [ ] Address comments on code and resolve requested changes
- [ ] Merge own code

## Description
Issue: #166 

This PR updates some of the data factories used for testing to be slightly more realistic. In particular, we add and use two custom providers to the Faker instance:
- `west_oakland_geo_point` produces a random (lat, lon) pair approximately within West Oakland. 
- `pollution_value` produces a random float between 0 and 0.050. 

We also add a custom manage.py command `generate_data` to run these factories. There are two optional parameters `--collections` and `--observations` to set how much data to generate (total of _N_ collections * _M_ observations-per-collection).

Looking for feedback:
- Where should I document how to use this?
- Right now one can easily shell into the `woaq-api` docker container and run `python manage.py generate_data` (two steps). Is it necessary to further simplify with a script to do this in one step?