### PR TITLE
Fix Codecov reporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ install:
   - pip install -U codecov
 
 script:
-  - docker-compose -f docker-compose.yml -f docker-compose.ci.yml run --name api api "make coverage"
-  - docker cp api:/usr/src/app/.coverage .coverage
+  - docker-compose -f docker-compose.yml -f docker-compose.ci.yml run --name api api "make coverage && coverage xml"
+  - docker cp api:/usr/src/app/coverage.xml coverage.xml
 
 after_success:
   - codecov -F api


### PR DESCRIPTION
---
name: Pull Request
about: Request merging changes into the code base
title: 'Fix Codecov reporting'
labels: ''
reviewers: ''

---

## Checklist
- [X] Add description
- [X] Reference open issue pull request addresses
- [X] Pass functional tests
  - complete on the local machine with `make local.shell` `make test`
- [X] Request code review
  - Please allow **36 hours** from opening a pull request before merging a pull request- even if it has already recieved an approving review.
- [ ] Address comments on code and resolve requested changes
- [ ] Merge own code

## Description
Resolves #168 

This PR fixes the CI scripts to integrate with Codecov.

In particular, for whatever reason, the call to `coverage xml` within the `codecov` upload script wasn't correctly picking up our `.coverage` file. Instead, I have updated our CI to explicitly call `coverage xml` in the API's Docker container and then copy that file out into the working directory. 

Reference: https://github.com/codecov/example-python