### PR TITLE
Upgrade to Django 3.0.2

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -31,7 +31,7 @@ These are general guidelines on the flow from design to implementation
 
   # 5. Run tests as described below
 
-  # 6. Create a pull request 
+  # 6. Create a pull request
 ```
 
 ## Issues
@@ -75,7 +75,7 @@ As the codebase develops, robust testing techniques ensure code integrity. With 
 appropriate tests.
 
 Testing resources include:
-- [Django Testing](https://docs.djangoproject.com/en/2.2/topics/testing/overview/)
+- [Django Testing](https://docs.djangoproject.com/en/3.0/topics/testing/)
 - [Python Faker](https://faker.readthedocs.io/en/master/)
 - [Pytest](https://docs.pytest.org/en/latest/)
 

--- a/api/requirements.in/prod.txt
+++ b/api/requirements.in/prod.txt
@@ -1,11 +1,11 @@
 argon2-cffi
-django==2.1.11
+django==3.0.2
 django-boto
 django-environ
 django-extensions
 django-model-utils
 django-storages
-djangorestframework
+djangorestframework==3.11.0
 drf-yasg
 gevent
 gunicorn==19.9.0

--- a/api/requirements/dev.txt
+++ b/api/requirements/dev.txt
@@ -5,6 +5,7 @@
 #    pip-compile --output-file=requirements/dev.txt requirements.in/dev.txt
 #
 argon2-cffi==19.1.0
+asgiref==3.2.3            # via django
 astroid==2.2.5
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
@@ -21,8 +22,8 @@ django-environ==0.4.5
 django-extensions==2.1.9
 django-model-utils==3.2.0
 django-storages==1.7.1
-django==2.1.11
-djangorestframework==3.10.2
+django==3.0.2
+djangorestframework==3.11.0
 drf-yasg==1.17.0
 factory-boy==2.12.0
 faker==2.0.0              # via factory-boy
@@ -56,7 +57,7 @@ requests==2.22.0          # via coreapi
 ruamel.yaml.clib==0.2.0   # via ruamel.yaml
 ruamel.yaml==0.16.5       # via drf-yasg
 six==1.12.0               # via argon2-cffi, astroid, django-extensions, drf-yasg, faker, packaging, python-dateutil
-sqlparse==0.3.0           # via django-debug-toolbar
+sqlparse==0.3.0           # via django, django-debug-toolbar
 text-unidecode==1.2       # via faker
 typed-ast==1.4.0          # via astroid, mypy
 typing-extensions==3.7.4  # via mypy

--- a/api/requirements/prod.txt
+++ b/api/requirements/prod.txt
@@ -5,6 +5,7 @@
 #    pip-compile --output-file=requirements/prod.txt requirements.in/prod.txt
 #
 argon2-cffi==19.1.0
+asgiref==3.2.3            # via django
 boto==2.49.0              # via django-boto
 certifi==2019.9.11        # via requests
 cffi==1.12.3              # via argon2-cffi
@@ -13,11 +14,11 @@ coreapi==2.3.3            # via drf-yasg
 coreschema==0.0.4         # via coreapi, drf-yasg
 django-boto==0.3.12
 django-environ==0.4.5
-django-extensions==2.1.9
+django-extensions==2.2.6
 django-model-utils==3.2.0
-django-storages==1.7.1
-django==2.1.11
-djangorestframework==3.10.2
+django-storages==1.8
+django==3.0.2
+djangorestframework==3.11.0
 drf-yasg==1.17.0
 gevent==1.4.0
 greenlet==0.4.15          # via gevent
@@ -40,5 +41,6 @@ requests==2.22.0          # via coreapi
 ruamel.yaml.clib==0.2.0   # via ruamel.yaml
 ruamel.yaml==0.16.5       # via drf-yasg
 six==1.12.0               # via argon2-cffi, django-extensions, drf-yasg, packaging, python-dateutil
+sqlparse==0.3.0           # via django
 uritemplate==3.0.0        # via coreapi, drf-yasg
 urllib3==1.25.7           # via requests


### PR DESCRIPTION
Upgrade Django from 2.1.11 to 3.0.2. All tests passed.

I decided to go to 3.0.2 (latest and greatest) rather than 2.2.9 (long-term support) since this was an opportunity to upgrade anyways, and we don't have _that_ complicated an application that there would be a high risk of migration problems. 

Resolves #174 