### PR TITLE
Test GitHub Actions for a consistent CI build experience 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,9 +9,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: install codecov
-      run: |
-        pip install -U codecov 
+#     - name: install codecov
+#       run: |
+#         pip install -U codecov 
     - name: Running docker scripts
       run: |
         docker-compose -f docker-compose.yml -f docker-compose.ci.yml build web

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,16 @@ on: [push]
 
 jobs:
   build:
-
+    env:
+      PYTHON_ENV: ${{ secrets.PYTHON_ENV }}
+      API_PORT: ${{ secrets.API_PORT }}
+      SECRET_KEY: ${{ secrets.SECRET_KEY }}
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      DEFAULT_FILE_STORAGE: ${{ secrets.DEFAULT_FILE_STORAGE }}
+      API_DOMAIN: ${{ secrets.API_DOMAIN }}
+      POSTGRES_USER: ${{ secrets.POSTGRES_USER }}
+      POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
+      POSTGRES_DB: ${{ secrets.POSTGRES_DB }}
     runs-on: ubuntu-latest
 
     steps:
@@ -23,13 +32,3 @@ jobs:
         file: ./coverage.xml
         yml: ./codecov.yml 
         fail_ci_if_error: true
-      env:
-        PYTHON_ENV: ${{ secrets.PYTHON_ENV }}
-        API_PORT: ${{ secrets.API_PORT }}
-        SECRET_KEY: ${{ secrets.SECRET_KEY }}
-        DATABASE_URL: ${{ secrets.DATABASE_URL }}
-        DEFAULT_FILE_STORAGE: ${{ secrets.DEFAULT_FILE_STORAGE }}
-        API_DOMAIN: ${{ secrets.API_DOMAIN }}
-        POSTGRES_USER: ${{ secrets.POSTGRES_USER }}
-        POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
-        POSTGRES_DB: ${{ secrets.POSTGRES_DB }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,15 +9,20 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: install codecov
+    - name: Build docker images
       run: |
-        pip install -U codecov 
-    - name: Running docker scripts
+        docker-compose -f docker-compose.yml -f docker-compose.ci.yml build
+    - name: Generate coverage report
       run: |
-        docker-compose -f docker-compose.yml -f docker-compose.ci.yml build web
-        docker-compose -f docker-compose.yml -f docker-compose.ci.yml build api
         docker-compose -f docker-compose.yml -f docker-compose.ci.yml run --name api api "make coverage && coverage xml"
         docker cp api:/usr/src/app/coverage.xml coverage.xml
+    - name: Upload coverage to Codecov  
+      uses: codecov/codecov-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        file: ./coverage.xml
+        yml: ./codecov.yml 
+        fail_ci_if_error: true
       env:
         PYTHON_ENV: ${{ secrets.PYTHON_ENV }}
         API_PORT: ${{ secrets.API_PORT }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,3 +15,13 @@ jobs:
         docker-compose -f docker-compose.yml -f docker-compose.ci.yml build api
         docker-compose -f docker-compose.yml -f docker-compose.ci.yml run --name api api "make coverage && coverage xml"
         docker cp api:/usr/src/app/coverage.xml coverage.xml
+      env:
+        PYTHON_ENV: ${{ secrets.PYTHON_ENV }}
+        API_PORT: ${{ secrets.API_PORT }}
+        SECRET_KEY: ${{ secrets.SECRET_KEY }}
+        DATABASE_URL: ${{ secrets.DATABASE_URL }}
+        DEFAULT_FILE_STORAGE: ${{ secrets.DEFAULT_FILE_STORAGE }}
+        API_DOMAIN: ${{ secrets.API_DOMAIN }}
+        POSTGRES_USER: ${{ secrets.POSTGRES_USER }}
+        POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
+        POSTGRES_DB: ${{ secrets.POSTGRES_DB }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Running docker scripts
+      run: |
+        docker-compose -f docker-compose.yml -f docker-compose.ci.yml build web
+        docker-compose -f docker-compose.yml -f docker-compose.ci.yml build api
+        docker-compose -f docker-compose.yml -f docker-compose.ci.yml run --name api api "make coverage && coverage xml"
+        docker cp api:/usr/src/app/coverage.xml coverage.xml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Install codecov
+    - name: install codecov
       run: |
         pip install -U codecov 
     - name: Running docker scripts

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,7 @@ on: [push]
 
 jobs:
   build:
+    runs-on: ubuntu-latest
     env:
       PYTHON_ENV: ${{ secrets.PYTHON_ENV }}
       API_PORT: ${{ secrets.API_PORT }}
@@ -14,13 +15,12 @@ jobs:
       POSTGRES_USER: ${{ secrets.POSTGRES_USER }}
       POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
       POSTGRES_DB: ${{ secrets.POSTGRES_DB }}
-    runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
     - name: Build docker images
       run: |
-        docker-compose -f docker-compose.yml -f docker-compose.ci.yml build
+        docker-compose -f docker-compose.yml -f docker-compose.ci.yml build web
+        docker-compose -f docker-compose.yml -f docker-compose.ci.yml build api
     - name: Generate coverage report
       run: |
         docker-compose -f docker-compose.yml -f docker-compose.ci.yml run --name api api "make coverage && coverage xml"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Install codecov
+      run: |
+        pip install -U codecov 
     - name: Running docker scripts
       run: |
         docker-compose -f docker-compose.yml -f docker-compose.ci.yml build web

--- a/web/package.json
+++ b/web/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "scripts": {
     "start": "razzle start",
-    "build": "cross-env NODE_OPTIONS=--max_old_space_size=4096 razzle build",
+    "build": "cross-env NODE_OPTIONS=--max_old_space_size=8192 razzle build",
     "test": "razzle test --env=jsdom",
     "start:prod": "NODE_ENV=production node build/server.js"
   },


### PR DESCRIPTION
---
name: Pull Request
about: Request merging changes into the code base
title: ''
labels: ''
reviewers: ''

---

## Checklist
- [x] Add description
- [x] Reference open issue pull request addresses
- [ ] Pass functional tests
  - complete on the local machine with `make local.shell` `make test`
- [ ] Request code review
  - Please allow **36 hours** from opening a pull request before merging a pull request- even if it has already recieved an approving review.
- [ ] Address comments on code and resolve requested changes
- [ ] Merge own code

## Description
Issue: #

@ifed3 explained that Travis was hitting memory issues, which was causing an inconsistent experience during the CI build process. I suggested testing out GitHub Actions to see if we could get a consistent experience.

Example failure: https://travis-ci.org/openoakland/woeip/builds/642702003?utm_source=github_status&utm_medium=notification
https://github.com/openoakland/woeip/pull/173

I also work for GitHub and with the Actions team pretty closely, so my suggestion was also biased :) 