### PR TITLE
Return to upload page after canceling file selection

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "cSpell.words": [
+        "dropzone",
+        "dustrak"
+    ]
+}

--- a/web/src/components/Upload/UploadConfirmation/index.tsx
+++ b/web/src/components/Upload/UploadConfirmation/index.tsx
@@ -14,6 +14,7 @@ import {
   getDustrakStart,
   getDustrakEnd
 } from 'components/Upload/util'
+import {ConfirmationProps} from 'components/Upload/UploadConfirmation/types'
 import axios from 'axios'
 import styled from 'theme'
 import moment from 'moment-timezone'
@@ -117,9 +118,7 @@ const options = [
   { key: 'd', text: 'Device D', value: 'Device D' }
 ]
 
-const UploadConfirmation: React.FunctionComponent<Array<
-  FileWithPath
->> = files => {
+const UploadConfirmation = ({files, setFiles, setProceed}: ConfirmationProps) => {
   const [dustrakText, setDustrakText] = useState<Array<string>>([])
   const [dustrakStart, setDustrakStart] = useState<moment.Moment>(moment(''))
   const history = useHistory()
@@ -168,7 +167,9 @@ const UploadConfirmation: React.FunctionComponent<Array<
   }
 
   const cancelUpload = () => {
-    history.push('/about')
+    // history.push('/about')
+    setFiles([])
+    setProceed(false)
   }
 
   return (

--- a/web/src/components/Upload/UploadConfirmation/index.tsx
+++ b/web/src/components/Upload/UploadConfirmation/index.tsx
@@ -125,8 +125,7 @@ const UploadConfirmation = ({files, setFiles, setProceed}: ConfirmationProps) =>
 
   useEffect(() => {
     const getDustrak = async () => {
-      // files passed to component as object but processed like array
-      const dustrakFile: File = identFiles([files[0], files[1]])[1]!
+      const dustrakFile: File = identFiles(files)[1]!
       const dustrakString: string = await dustrakFile.text()
       const dustrakTextUpdate: Array<string> = dustrakString.split('\n', 10)
       const dustrakStartUpdate: moment.Moment = getDustrakStart(
@@ -167,7 +166,6 @@ const UploadConfirmation = ({files, setFiles, setProceed}: ConfirmationProps) =>
   }
 
   const cancelUpload = () => {
-    // history.push('/about')
     setFiles([])
     setProceed(false)
   }

--- a/web/src/components/Upload/UploadConfirmation/index.tsx
+++ b/web/src/components/Upload/UploadConfirmation/index.tsx
@@ -14,7 +14,7 @@ import {
   getDustrakStart,
   getDustrakEnd
 } from 'components/Upload/util'
-import {ConfirmationProps} from 'components/Upload/UploadConfirmation/types'
+import { ConfirmationProps } from 'components/Upload/UploadConfirmation/types'
 import axios from 'axios'
 import styled from 'theme'
 import moment from 'moment-timezone'
@@ -118,7 +118,11 @@ const options = [
   { key: 'd', text: 'Device D', value: 'Device D' }
 ]
 
-const UploadConfirmation = ({files, setFiles, setProceed}: ConfirmationProps) => {
+const UploadConfirmation = ({
+  files,
+  setFiles,
+  setProceed
+}: ConfirmationProps) => {
   const [dustrakText, setDustrakText] = useState<Array<string>>([])
   const [dustrakStart, setDustrakStart] = useState<moment.Moment>(moment(''))
   const history = useHistory()

--- a/web/src/components/Upload/UploadConfirmation/types.ts
+++ b/web/src/components/Upload/UploadConfirmation/types.ts
@@ -1,7 +1,7 @@
-import {FileWithPath} from 'react-dropzone'
+import { FileWithPath } from 'react-dropzone'
 
 export type ConfirmationProps = {
-    files: FileWithPath[]
-    setFiles: (files: FileWithPath[]) => void
-    setProceed: (proceed: boolean) => void
+  files: Array<FileWithPath>
+  setFiles: (files: Array<FileWithPath>) => void
+  setProceed: (proceed: boolean) => void
 }

--- a/web/src/components/Upload/UploadConfirmation/types.ts
+++ b/web/src/components/Upload/UploadConfirmation/types.ts
@@ -1,0 +1,7 @@
+import {FileWithPath} from 'react-dropzone'
+
+export type ConfirmationProps = {
+    files: FileWithPath[]
+    setFiles: (files: FileWithPath[]) => void
+    setProceed: (proceed: boolean) => void
+}

--- a/web/src/components/Upload/index.tsx
+++ b/web/src/components/Upload/index.tsx
@@ -118,8 +118,7 @@ const Upload: React.FunctionComponent = () => {
     setFiles(files.filter((_, i) => i !== removeIndex))
   }
 
-  const uploadPage =
-    files.length !== 2 || proceed === false ? (
+  return proceed === false ? (
       <StyledContainer>
         <Dropzone {...getRootProps({ refKey: 'ref' })}>
           <InstructionsContainer>
@@ -162,8 +161,6 @@ const Upload: React.FunctionComponent = () => {
       setFiles={setFiles}
       setProceed={setProceed}/>
     )
-
-  return uploadPage
 }
 
 export default Upload

--- a/web/src/components/Upload/index.tsx
+++ b/web/src/components/Upload/index.tsx
@@ -119,48 +119,49 @@ const Upload: React.FunctionComponent = () => {
   }
 
   return proceed === false ? (
-      <StyledContainer>
-        <Dropzone {...getRootProps({ refKey: 'ref' })}>
-          <InstructionsContainer>
-            <p>Drag a pair of DusTrak and GPS files here</p>
-            <FileSelector>
-              <span>or</span>
-              <FileInput>
-                Select files from your computer
-                <input {...getInputProps()} />
-              </FileInput>
-            </FileSelector>
-          </InstructionsContainer>
-        </Dropzone>
-        <StyledMessage hidden={errorMessage === ''}>
-          <WarningIcon />
-          {errorMessage}
-        </StyledMessage>
-        {files.length > 0 && (
-          <PendingContainer>
-            <h3>Pending Files</h3>
-            <hr />
-            <ul>
-              {files.map((file, i) => (
-                <PendingFile key={file.path}>
-                  <FileNameContainer>
-                    <FileName>{file.path}</FileName>
-                  </FileNameContainer>
-                  <IconButton icon={true} data-arg={i} onClick={removeItem}>
-                    <Icon name='trash' />
-                  </IconButton>
-                </PendingFile>
-              ))}
-            </ul>
-          </PendingContainer>
-        )}
-      </StyledContainer>
-    ) : (
-      <UploadConfirmation 
-      files={files} 
+    <StyledContainer>
+      <Dropzone {...getRootProps({ refKey: 'ref' })}>
+        <InstructionsContainer>
+          <p>Drag a pair of DusTrak and GPS files here</p>
+          <FileSelector>
+            <span>or</span>
+            <FileInput>
+              Select files from your computer
+              <input {...getInputProps()} />
+            </FileInput>
+          </FileSelector>
+        </InstructionsContainer>
+      </Dropzone>
+      <StyledMessage hidden={errorMessage === ''}>
+        <WarningIcon />
+        {errorMessage}
+      </StyledMessage>
+      {files.length > 0 && (
+        <PendingContainer>
+          <h3>Pending Files</h3>
+          <hr />
+          <ul>
+            {files.map((file, i) => (
+              <PendingFile key={file.path}>
+                <FileNameContainer>
+                  <FileName>{file.path}</FileName>
+                </FileNameContainer>
+                <IconButton icon={true} data-arg={i} onClick={removeItem}>
+                  <Icon name='trash' />
+                </IconButton>
+              </PendingFile>
+            ))}
+          </ul>
+        </PendingContainer>
+      )}
+    </StyledContainer>
+  ) : (
+    <UploadConfirmation
+      files={files}
       setFiles={setFiles}
-      setProceed={setProceed}/>
-    )
+      setProceed={setProceed}
+    />
+  )
 }
 
 export default Upload

--- a/web/src/components/Upload/index.tsx
+++ b/web/src/components/Upload/index.tsx
@@ -157,7 +157,10 @@ const Upload: React.FunctionComponent = () => {
         )}
       </StyledContainer>
     ) : (
-      <UploadConfirmation {...files} />
+      <UploadConfirmation 
+      files={files} 
+      setFiles={setFiles}
+      setProceed={setProceed}/>
     )
 
   return uploadPage


### PR DESCRIPTION
## Checklist
- [x] Add description
- [x] Reference open issue pull request addresses
- [x] Pass functional tests
  - spin up docker container service `docker up -d --build`
  - enter api container `docker-compose exec api /bin/bash`
  - run api tests `make test`
  - exit container `ctrl/command+D` or `exit`
  - enter web container `docker-compose exec web /bin/sh`
  - run front-end tests `npm test` or `jest`
  - lint `npm run lint` or `tslint -p .` with optional `--fix` 
  - exit container `ctrl/command+D` or `exit`
- [x] Request code review
  - Please allow **36 hours** from opening a pull request before merging a pull request- even if it has already recieved an approving review.
- [ ] Address comments on code and resolve requested changes
- [ ] Merge own code

## Description
Issue: #231 

*Brief description of solution*
1) Refactor UploadConfirmation properties to accept multiple parameters, add property types as well
2) Send Files as an intact array, rather than a spread array. Update identFiles call appropriately
3) Send `setState` and `setProceed` as properties to UploadConfirmation
4) When canceling and upload, drop the files and set proceed to false

*Out of original issue scope: light refactoring* The criteria to proceed already accounts for number of files to equal two. Code can be cleaned by removing the file count check in the ternary operator that toggles the components.
