### PR TITLE
Ajay map updates

### DIFF
--- a/api/woeip/urls.py
+++ b/api/woeip/urls.py
@@ -1,6 +1,8 @@
 from django.contrib import admin
 from django.urls import include
 from django.urls import path
+from django.conf.urls.static import static
+from django.conf import settings
 from rest_framework import routers
 
 from .apps.air_quality import views
@@ -26,3 +28,4 @@ urlpatterns = [
 ]
 
 urlpatterns += swagger_urlpatterns
+urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/web/src/components/Map/ControlPanel/elements.tsx
+++ b/web/src/components/Map/ControlPanel/elements.tsx
@@ -59,7 +59,19 @@ export const NoDataText = styled.label`
   font-weight: bold;
 `
 
+export const SessionDataContainer = styled.div`
+  position: relative;
+  height: 100%;
+`
+
 export const SessionLabel = styled.p`
   text-decoration: underline;
   cursor: pointer;
+`
+
+export const ViewDataLabel = styled.p`
+  text-decoration: underline;
+  cursor: pointer;
+  position: absolute;
+  bottom: 0;
 `

--- a/web/src/components/Map/ControlPanel/index.tsx
+++ b/web/src/components/Map/ControlPanel/index.tsx
@@ -36,21 +36,24 @@ const ControlPanel = ({
     setPollutants([])
     const source = axios.CancelToken.source()
     setCurrentCollection(collection)
+    console.log('hi')
     getPollutants(source.token, collectionId)
-      .then(pollutants =>
-        pollutants
-          ? setPollutants(pollutants as Pollutant[])
-          : setPollutants([])
-      )
+      .then(pollutants => {
+        if (pollutants) {
+          setPollutants(pollutants as Pollutant[])
+        } else {
+          setPollutants([])
+        }
+        console.log('hey')
+      })
       .catch((error: Error) => console.log(error))
   }
 
-  const openData = (
-    event: React.MouseEvent<HTMLSpanElement>) => {
-      event.preventDefault();
-      window.open(`${currentCollection.collection_files[0]}`)
-      window.open(`${currentCollection.collection_files[1]}`)
-    }
+  const openData = (event: React.MouseEvent<HTMLSpanElement>) => {
+    event.preventDefault()
+    window.open(`${currentCollection.collection_files[0]}`)
+    window.open(`${currentCollection.collection_files[1]}`)
+  }
 
   const sessionTime = (starts_at: string) => {
     const parsed = moment(starts_at)

--- a/web/src/components/Map/ControlPanel/index.tsx
+++ b/web/src/components/Map/ControlPanel/index.tsx
@@ -12,6 +12,7 @@ const ControlPanel = ({
   date,
   setDate,
   setPollutants,
+  setLoading,
   collections,
   currentCollection,
   setCurrentCollection,
@@ -36,7 +37,7 @@ const ControlPanel = ({
     setPollutants([])
     const source = axios.CancelToken.source()
     setCurrentCollection(collection)
-    console.log('hi')
+    setLoading(true)
     getPollutants(source.token, collectionId)
       .then(pollutants => {
         if (pollutants) {
@@ -44,7 +45,7 @@ const ControlPanel = ({
         } else {
           setPollutants([])
         }
-        console.log('hey')
+        setLoading(false)
       })
       .catch((error: Error) => console.log(error))
   }

--- a/web/src/components/Map/ControlPanel/index.tsx
+++ b/web/src/components/Map/ControlPanel/index.tsx
@@ -29,6 +29,14 @@ const ControlPanel = ({
     getPollutants(source.token, collections[collectionIdx])
   }
 
+  const openData = (
+    event: React.MouseEvent<HTMLSpanElement>) => {
+      event.preventDefault();
+      window.open(`${currentCollection.collection_files[0]}`)
+      window.open(`${currentCollection.collection_files[1]}`)
+    }
+
+
   const sessionTime = (starts_at: any) => {
     const parsed = moment(starts_at)
     return parsed.format('h:mm A')
@@ -59,7 +67,7 @@ const ControlPanel = ({
   const sessionInformation = () => {
     if (collections.length > 0 && currentCollection) {
       return (
-        <div>
+        <Elements.SessionDataContainer>
           <Elements.LabelContainer>
             <Elements.BoldedLabel>Session:</Elements.BoldedLabel>
             <Elements.TextLabel>
@@ -86,7 +94,14 @@ const ControlPanel = ({
             </Elements.BoldedSessionLabel>
             {collectionList()}
           </Elements.SessionLabelContainer>
-        </div>
+          <Elements.ViewDataLabel
+            onClick={e => {
+              openData(e)
+            }}
+          >
+            Download Raw Data
+          </Elements.ViewDataLabel>
+        </Elements.SessionDataContainer>
       )
     } else {
       return (

--- a/web/src/components/Map/ControlPanel/index.tsx
+++ b/web/src/components/Map/ControlPanel/index.tsx
@@ -51,6 +51,7 @@ const ControlPanel = ({
   }
 
   const openData = (event: React.MouseEvent<HTMLSpanElement>) => {
+    debugger
     event.preventDefault()
     window.open(`${currentCollection.collection_files[0]}`)
     window.open(`${currentCollection.collection_files[1]}`)

--- a/web/src/components/Map/ControlPanel/index.tsx
+++ b/web/src/components/Map/ControlPanel/index.tsx
@@ -51,7 +51,6 @@ const ControlPanel = ({
   }
 
   const openData = (event: React.MouseEvent<HTMLSpanElement>) => {
-    debugger
     event.preventDefault()
     window.open(`${currentCollection.collection_files[0]}`)
     window.open(`${currentCollection.collection_files[1]}`)

--- a/web/src/components/Map/ControlPanel/types.ts
+++ b/web/src/components/Map/ControlPanel/types.ts
@@ -6,6 +6,7 @@ export type ControlPanelProps = {
   date: moment.Moment
   setDate: (date: moment.Moment) => void
   setPollutants: (pollutants: Pollutant[]) => void
+  setLoading: (loading: boolean) => void
   collections: Array<Collection>
   currentCollection: Collection
   setCurrentCollection: (collection: Collection) => void

--- a/web/src/components/Map/elements.tsx
+++ b/web/src/components/Map/elements.tsx
@@ -1,5 +1,5 @@
 import styled from 'theme'
-import { Container } from 'semantic-ui-react'
+import { Container, Segment } from 'semantic-ui-react'
 
 export const StyledContainer = styled(Container)`
   margin-top: 30px;
@@ -14,10 +14,15 @@ export const LowerHalfContainer = styled.div`
   display: flex;
 `
 
-export const MapContainer = styled.div`
-  height: 548px;
-  width: 65%;
-`
+export const MapContainer = styled(Segment)`
+         height: 548px;
+         width: 65%;
+         margin: 0px !important;
+         padding: 0px !important;
+         border-radius: 0px !important;
+         border: none !important;
+         box-shadow: none !important;
+       `
 
 export const ControlPanelContainer = styled.div`
   height: 548px;
@@ -27,4 +32,7 @@ export const ControlPanelContainer = styled.div`
 
 export const FormMessage = styled.h3`
   font-size: 1.5rem;
+`
+
+export const LoadingContainer = styled.div`
 `

--- a/web/src/components/Map/index.tsx
+++ b/web/src/components/Map/index.tsx
@@ -8,68 +8,8 @@ import * as Elements from 'components/Map/elements'
 import ControlPanel from 'components/Map/ControlPanel'
 // import MapFilters from 'components/Map/ControlPanel'
 import Pin from 'components/Map/Pin'
-<<<<<<< HEAD
-import {
-  Pollutant,
-  PollutantValueResponse,
-  Viewport
-} from 'components/Map/types'
-import {
-  MAPBOX_ACCESS_TOKEN,
-  MAP_STYLE
-} from '../../constants'
-
-const StyledContainer = styled(Container)`
-  margin-top: 30px;
-`
-
-const ContentContainer = styled.div`
-  margin: 0px 130px 92px 130px;
-`
-
-const LowerHalfContainer = styled.div`
-  margin-top: 22px;
-  display: flex;
-`
-
-const MapContainer = styled.div`
-  height: 548px;
-  width: 65%;
-`
-
-const ControlPanelContainer = styled.div`
-  height: 548px;
-  width: 35%;
-  padding-left: 54px;
-`
-
-const FormMessage = styled.h3`
-  font-size: 1.5rem;
-`
-
-const initialViewport: Viewport = {
-  zoom: 12,
-  latitude: 37.812036,
-  longitude: -122.286675,
-  bearing: 0,
-  pitch: 0
-}
-
-const parsePollutant = (item: PollutantValueResponse): Pollutant => {
-  const timeGeoSplit = item.time_geo.split('(')
-  const coordsSplit = timeGeoSplit[1].split(', ')
-  return {
-    timestamp: timeGeoSplit[0].trim(),
-    longitude: Number(coordsSplit[0].trim()),
-    latitude: Number(coordsSplit[1].replace(')', '').trim()),
-    name: item.pollutant,
-    value: item.value
-  }
-}
-=======
 import { Pollutant, Viewport } from 'components/Map/types'
 import { MAPBOX_ACCESS_TOKEN, MAP_STYLE, API_URL } from '../../constants'
->>>>>>> master
 
 const Map: FunctionComponent<{}> = () => {
   const [date, setDate] = useState<moment.Moment>(moment())

--- a/web/src/components/Map/index.tsx
+++ b/web/src/components/Map/index.tsx
@@ -36,12 +36,16 @@ const Map: FunctionComponent<{}> = () => {
           setCollections(collections)
           const firstCollection = collections[0]
           setCurrentCollection(collections[0])
+          console.log('hi')
           getPollutants(token, firstCollection.id)
-            .then(pollutants =>
-              pollutants
-                ? setPollutants(pollutants as Pollutant[])
-                : setPollutants([])
-            )
+            .then(pollutants => {
+              if (pollutants){
+                setPollutants(pollutants as Pollutant[])
+              } else {
+                setPollutants([])
+              }
+              console.log('hey')
+            })
             .catch((error: Error) => console.log(error))
         } else {
           setPollutants([])

--- a/web/src/components/Map/index.tsx
+++ b/web/src/components/Map/index.tsx
@@ -17,6 +17,7 @@ const Map: FunctionComponent<{}> = () => {
   const [collections, setCollections] = useState<Array<Collection>>([])
   const [pollutants, setPollutants] = useState<Array<Pollutant>>([])
   const [viewport, setViewport] = useState<Viewport>(initialViewport)
+  const [loading, setLoading] = useState<Boolean>(false)
 
   const markers = pollutants.map((coordinates: Coordinates, index: number) => (
     <Pin key={index} coordinates={coordinates} />
@@ -36,7 +37,9 @@ const Map: FunctionComponent<{}> = () => {
           setCollections(collections)
           const firstCollection = collections[0]
           setCurrentCollection(collections[0])
-          console.log('hi')
+          setLoading(true)
+          var map = document.querySelectorAll<HTMLElement>('.overlays')[0]
+          map.style.background = 'rgba(0, 0, 0, 0.7)'
           getPollutants(token, firstCollection.id)
             .then(pollutants => {
               if (pollutants){
@@ -44,7 +47,8 @@ const Map: FunctionComponent<{}> = () => {
               } else {
                 setPollutants([])
               }
-              console.log('hey')
+              setLoading(false)
+              map.style.background = ''
             })
             .catch((error: Error) => console.log(error))
         } else {
@@ -74,6 +78,7 @@ const Map: FunctionComponent<{}> = () => {
               width='100%'
               height='100%'
               mapStyle={MAP_STYLE}
+              className="sup"
               onViewportChange={setViewport}
               mapboxApiAccessToken={MAPBOX_ACCESS_TOKEN}
             >

--- a/web/src/components/Map/index.tsx
+++ b/web/src/components/Map/index.tsx
@@ -1,5 +1,6 @@
 import axios, { AxiosResponse, CancelToken } from 'axios'
 import React, { FunctionComponent, useEffect, useState } from 'react'
+import { useLocation, useHistory } from 'react-router-dom'
 import ReactMapGL from 'react-map-gl'
 import moment from 'moment-timezone'
 import { Dimmer, Loader, Segment } from 'semantic-ui-react'
@@ -12,13 +13,15 @@ import Pin from 'components/Map/Pin'
 import { Pollutant, Viewport } from 'components/Map/types'
 import { MAPBOX_ACCESS_TOKEN, MAP_STYLE, API_URL } from '../../constants'
 
-const Map: FunctionComponent<{}> = () => {
+const Map: FunctionComponent<{}> = props => {
   const [date, setDate] = useState<moment.Moment>(moment())
   const [currentCollection, setCurrentCollection] = useState<Collection>()
   const [collections, setCollections] = useState<Array<Collection>>([])
   const [pollutants, setPollutants] = useState<Array<Pollutant>>([])
   const [viewport, setViewport] = useState<Viewport>(initialViewport)
   const [loading, setLoading] = useState<boolean>(false)
+  const location = useLocation()
+  const history = useHistory()
 
   const markers = pollutants.map((coordinates: Coordinates, index: number) => (
     <Pin key={index} coordinates={coordinates} />
@@ -37,7 +40,15 @@ const Map: FunctionComponent<{}> = () => {
           )
           setCollections(collections)
           const firstCollection = collections[0]
-          setCurrentCollection(collections[0])
+          const lastCollection = collections[collections.length - 1]
+
+          //if we are coming from a push from the upload page - i.e there
+          //exists a location state that's not empty, set most recent collection
+          location.state !== undefined && Object.keys(location.state).length > 0
+            ? setCurrentCollection(lastCollection)
+            : setCurrentCollection(firstCollection)
+          //clears location state so now just first collection is set
+          history.replace({ pathname: '/maps', state: {} })
           setLoading(true)
           getPollutants(token, firstCollection.id)
             .then(pollutants => {
@@ -57,8 +68,15 @@ const Map: FunctionComponent<{}> = () => {
       })
       .catch(error => console.log(error))
   }
+  //if pushed from upload, sets date to date from upload
+  useEffect(() => {
+    if (location.state) {
+      if (!moment(location.state.date).isSame(date)) {
+        setDate(moment(location.state.date))
+      }
+    }
+  }, [])
 
-  // Request pollutant values on mount
   useEffect(() => {
     const source = axios.CancelToken.source()
     getCollections(source.token)

--- a/web/src/components/Map/index.tsx
+++ b/web/src/components/Map/index.tsx
@@ -2,6 +2,7 @@ import axios, { AxiosResponse, CancelToken } from 'axios'
 import React, { FunctionComponent, useEffect, useState } from 'react'
 import ReactMapGL from 'react-map-gl'
 import moment from 'moment-timezone'
+import { Dimmer, Loader, Segment } from 'semantic-ui-react'
 import { Collection, Coordinates } from 'components/Map/types'
 import { initialViewport, getPollutants } from 'components/Map/utils'
 import * as Elements from 'components/Map/elements'
@@ -17,7 +18,7 @@ const Map: FunctionComponent<{}> = () => {
   const [collections, setCollections] = useState<Array<Collection>>([])
   const [pollutants, setPollutants] = useState<Array<Pollutant>>([])
   const [viewport, setViewport] = useState<Viewport>(initialViewport)
-  const [loading, setLoading] = useState<Boolean>(false)
+  const [loading, setLoading] = useState<boolean>(false)
 
   const markers = pollutants.map((coordinates: Coordinates, index: number) => (
     <Pin key={index} coordinates={coordinates} />
@@ -38,17 +39,14 @@ const Map: FunctionComponent<{}> = () => {
           const firstCollection = collections[0]
           setCurrentCollection(collections[0])
           setLoading(true)
-          var map = document.querySelectorAll<HTMLElement>('.overlays')[0]
-          map.style.background = 'rgba(0, 0, 0, 0.7)'
           getPollutants(token, firstCollection.id)
             .then(pollutants => {
-              if (pollutants){
+              if (pollutants) {
                 setPollutants(pollutants as Pollutant[])
               } else {
                 setPollutants([])
               }
               setLoading(false)
-              map.style.background = ''
             })
             .catch((error: Error) => console.log(error))
         } else {
@@ -78,18 +76,21 @@ const Map: FunctionComponent<{}> = () => {
               width='100%'
               height='100%'
               mapStyle={MAP_STYLE}
-              className="sup"
               onViewportChange={setViewport}
               mapboxApiAccessToken={MAPBOX_ACCESS_TOKEN}
             >
               {markers.length ? markers : null}
             </ReactMapGL>
+            <Dimmer active={loading}>
+              <Loader indeterminate>Loading Pollutant Data...</Loader>
+            </Dimmer>
           </Elements.MapContainer>
           <Elements.ControlPanelContainer>
             <ControlPanel
               date={date}
               setDate={setDate}
               setPollutants={setPollutants}
+              setLoading={setLoading}
               collections={collections}
               currentCollection={currentCollection as Collection}
               setCurrentCollection={setCurrentCollection}

--- a/web/src/components/Map/index.tsx
+++ b/web/src/components/Map/index.tsx
@@ -14,8 +14,7 @@ import {
 } from 'components/Map/types'
 import {
   MAPBOX_ACCESS_TOKEN,
-  MAP_STYLE,
-  POLLUTANTS_API_URL
+  MAP_STYLE
 } from '../../constants'
 
 const StyledContainer = styled(Container)`
@@ -138,7 +137,6 @@ const Map: FunctionComponent<{}> = () => {
               mapboxApiAccessToken={MAPBOX_ACCESS_TOKEN}
             >
               {markers.length ? markers : null}
-              {/* <MapFilters /> */}
             </ReactMapGL>
           </MapContainer>
           <ControlPanelContainer>

--- a/web/src/components/Upload/Confirmation/index.tsx
+++ b/web/src/components/Upload/Confirmation/index.tsx
@@ -144,7 +144,12 @@ const Confirmation = ({
       })
       .then(d => {
         console.log('response data is:', d)
-        history.push('/maps')
+        history.push({
+          pathname: '/maps',
+          state: {
+            date: dustrakStart.format('MM/DD/YYYY')
+          }
+        })
       })
       .catch(error => {
         console.error(error)

--- a/web/src/constants.ts
+++ b/web/src/constants.ts
@@ -1,8 +1,5 @@
-<<<<<<< HEAD
-=======
 export const API_URL = 'http://api.lvh.me'
 export const POLLUTANTS_API_URL = 'http://api.lvh.me/collection/1/data'
->>>>>>> master
 export const MAP_STYLE = 'mapbox://styles/mapbox/streets-v11'
 export const MAPBOX_ACCESS_TOKEN =
   process.env.MAPBOX_ACCESS_TOKEN ||

--- a/web/src/constants.ts
+++ b/web/src/constants.ts
@@ -1,4 +1,3 @@
-export const POLLUTANTS_API_URL = 'http://api.lvh.me/collection/1/data'
 export const MAP_STYLE = 'mapbox://styles/mapbox/streets-v11'
 export const MAPBOX_ACCESS_TOKEN =
   process.env.MAPBOX_ACCESS_TOKEN ||


### PR DESCRIPTION
## Checklist
- [X] Add description
- [X] Reference the open issue that the pull request addresses
- [X] Pass code quality checks
  - spin up docker `docker-compose up -d --build`
  - enter api container `docker-compose exec api /bin/bash`
  - run api tests `make validate`
  - exit container `ctrl/command+D` or `exit`
  - enter web container `docker-compose exec web /bin/sh`
  - run front-end tests `npm run test` or `npx jest`
  - lint `npm run lint-fix`
  - exit container as above
- [X] Request code review
  - Please allow **36 hours** from opening a pull request before merging a pull request- even if it has already received an approving review.
- [x] Address comments on code and resolve requested changes
- [x] Merge own code

## Description
Issue: #261 #257 #260

This pull request:

* Adds a loading indicator on the map when pulling the pollution data
* Pushes user to the appropriate map date after uploading their data
* Adds a 'Download Raw Data' button which almost gets us to download the data (more on that below).

## Next Steps

In order to get to Map UI MVP - there are 4 steps developers can take right now

1. Issue #259: Add 'Device Type' as a column to the `Collection` Table, have the frontend include that in the `formData` upon upload, and then pull that for the map display. 

2. Complete issue #260 - I've gotten the 'Download Raw Data' div in the `ControlPanel` component to bring us to the API endpoint which contains the relevant files - but can't key into `currentCollection.collection_files[0].file` even though I can see the `file` parameter in the `currentCollection.collection_files[0]` object. That code is found lines 53-57 of the `ControlPanel` index.tsx file.

3. Issue #258 - 'cancel' is being logged to the console every time we call the `getCollections` function in the map component. I don't know if we just need to remove that `console.log(error)` or if there's something not ideal happening.

4. Bug that appeared during demo - after we changed dates, the API call and pollution data parsing were not cancelled and the pins still appeared on dates where there were no collections. 

For future work to get to Map UI MVP - as a team we need to have discussions about:

1. Part of issue #257 - specifically about the second checkbox - pushing the user to the map immediately after clicking save. I don't think this will be ideal with what's happening under the hood - the `collections` for the specific dates are called as soon as the component is mounted, and if we push to the map page without the newest collection being successfully saved yet, I can see it not coming up. I think there should be some loading indicator on the upload page after clicking save that we could design out.

2. Issue #237 - developers can implement the 'air quality this session/today' display that appears on the [wireframe](https://www.figma.com/file/IZw8VvX1CsRc764CTvg4aRSU/WOAQ-Wireframes-Parent-File?node-id=753%3A0) once we figure out how we are going to calculate that. Currently we pull just collection pollution data one session at a time (was too slow and erroring out when we pulled all sessions from a day) - so we will have to think of something to get daily aggregate data and then processing that. Maybe upon save - the backend ends up parsing the files and saving an average AQ index per `Collection` instance, and then the frontend can average out the daily `Collection` AQ indexes after it retrieves the `Collections` set per day. 


