### PR TITLE
state for whether the button is uploading and style to reflect it

### DIFF
--- a/web/src/components/Upload/Confirmation/index.tsx
+++ b/web/src/components/Upload/Confirmation/index.tsx
@@ -138,6 +138,7 @@ const Confirmation = ({
   const [dustrakStart, setDustrakStart] = useState<moment.Moment>(moment(''))
   const [dustrakSerial, setDustrakSerial] = useState<string>('')
   const [showModal, setShowModal] = useState<boolean>(false)
+  const [isSaving, setIsSaving] = useState<boolean>(false)
   const history = useHistory()
 
   useEffect(() => {
@@ -155,6 +156,7 @@ const Confirmation = ({
     })()
   }, [files])
   const upload = (e: React.FormEvent) => {
+    setIsSaving(true)
     e.preventDefault()
     const formData = new FormData()
 
@@ -186,6 +188,8 @@ const Confirmation = ({
         console.error(error)
         alert(`files failed to upload: ${error.message}`)
       })
+
+      return () => setIsSaving(false)
   }
 
   const cancelUpload = () => {
@@ -219,10 +223,10 @@ const Confirmation = ({
             <DisabledInput value={devices[dustrakSerial]} disabled={true} />
             <InputLabel>Device</InputLabel>
             <SubmitForm onSubmit={upload}>
-              <SaveButton type='submit'>Save</SaveButton>
-              <CancelButton type='button' onClick={() => setShowModal(true)}>
+              <SaveButton type='submit' loading={isSaving}>Save</SaveButton>
+              { !isSaving && <CancelButton type='button' onClick={() => setShowModal(true)}>
                 Cancel
-              </CancelButton>
+              </CancelButton>}
             </SubmitForm>
           </FormContent>
         </FormContainer>


### PR DESCRIPTION
## Checklist
- [x] Add description
- [x] Reference the open issue that the pull request addresses
- [x] Pass code quality checks
  - spin up docker `docker-compose up -d --build`
  - enter api container `docker-compose exec api /bin/bash`
  - run api tests `make validate`
  - exit container `ctrl/command+D` or `exit`
  - enter web container `docker-compose exec web /bin/sh`
  - run front-end tests `npm run test` or `npx jest`
  - lint `npm run lint-fix`
  - exit container as above
- [x] Request code review
  - Please allow **36 hours** from opening a pull request before merging a pull request- even if it has already received an approving review.
- [ ] Address comments on code and resolve requested changes
- [ ] Merge own code

## Description
Issue: #280

*Brief description of solution*
Once the saving process starts, we set the `isSaving` state to true and add 'loading' styling to the existing save button.
I also disabled the "Cancel" Button once the upload start because... well at that point it's too late 😱 (it is possible to cancel the network request. That's just not how our cancel button currently works).
The `return` and the end of `useEffect` cleans up the state of `isSaving` to make sure its false when the component is unmounted.
