### PR TITLE
361 robust map calls

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -29,6 +29,7 @@
         "@typescript-eslint/parser": "^4.15.1",
         "eslint-config-prettier": "^7.2.0",
         "eslint-plugin-prettier": "^3.3.1",
+        "msw": "^0.35.0",
         "prettier": "^2.2.1",
         "typescript": "^4.1.5"
       }
@@ -2382,6 +2383,30 @@
         "gl-matrix": "^3.0.0"
       }
     },
+    "node_modules/@mswjs/cookies": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-0.1.6.tgz",
+      "integrity": "sha512-A53XD5TOfwhpqAmwKdPtg1dva5wrng2gH5xMvklzbd9WLTSVU953eCRa8rtrrm6G7Cy60BOGsBRN89YQK0mlKA==",
+      "dev": true,
+      "dependencies": {
+        "@types/set-cookie-parser": "^2.4.0",
+        "set-cookie-parser": "^2.4.6"
+      }
+    },
+    "node_modules/@mswjs/interceptors": {
+      "version": "0.12.7",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.12.7.tgz",
+      "integrity": "sha512-eGjZ3JRAt0Fzi5FgXiV/P3bJGj0NqsN7vBS0J0FO2AQRQ0jCKQS4lEFm4wvlSgKQNfeuc/Vz6d81VtU3Gkx/zg==",
+      "dev": true,
+      "dependencies": {
+        "@open-draft/until": "^1.0.3",
+        "@xmldom/xmldom": "^0.7.2",
+        "debug": "^4.3.2",
+        "headers-utils": "^3.0.2",
+        "outvariant": "^1.2.0",
+        "strict-event-emitter": "^0.2.0"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz",
@@ -2436,6 +2461,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/@open-draft/until": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-1.0.3.tgz",
+      "integrity": "sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==",
+      "dev": true
     },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
       "version": "0.4.3",
@@ -3219,6 +3250,12 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "node_modules/@types/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
+      "dev": true
+    },
     "node_modules/@types/eslint": {
       "version": "7.2.6",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.6.tgz",
@@ -3260,6 +3297,16 @@
       "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-5.1.1.tgz",
       "integrity": "sha512-giAlZwstKbmvMk1OO7WXSj4OZ0keXAcl2TQq4LWHiiPH2ByaH7WeUzng+Qej8UPxxv+8lRTuouo0iaNDBuzIBA=="
     },
+    "node_modules/@types/inquirer": {
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/@types/inquirer/-/inquirer-7.3.3.tgz",
+      "integrity": "sha512-HhxyLejTHMfohAuhRun4csWigAMjXTmRyiJTU1Y/I1xmggikFMkOUoMQRlFm+zQcPEGHSs3io/0FAmNZf8EymQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/through": "*",
+        "rxjs": "^6.4.0"
+      }
+    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
@@ -3290,6 +3337,12 @@
         "jest-diff": "^26.0.0",
         "pretty-format": "^26.0.0"
       }
+    },
+    "node_modules/@types/js-levenshtein": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@types/js-levenshtein/-/js-levenshtein-1.1.0.tgz",
+      "integrity": "sha512-14t0v1ICYRtRVcHASzes0v/O+TIeASb8aD55cWF1PidtInhFWSXcmhzhHqGjUWf9SUq1w70cvd1cWKUULubAfQ==",
+      "dev": true
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.7",
@@ -3347,6 +3400,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/set-cookie-parser": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@types/set-cookie-parser/-/set-cookie-parser-2.4.1.tgz",
+      "integrity": "sha512-N0IWe4vT1w5IOYdN9c9PNpQniHS+qe25W4tj4vfhJDJ9OkvA/YA55YUhaC+HNmMMeLlOSnBW9UMno0qlt5xu3Q==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/source-list-map": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/@types/source-list-map/-/source-list-map-0.1.2.tgz",
@@ -3369,6 +3431,15 @@
       "dev": true,
       "dependencies": {
         "@types/jest": "*"
+      }
+    },
+    "node_modules/@types/through": {
+      "version": "0.0.30",
+      "resolved": "https://registry.npmjs.org/@types/through/-/through-0.0.30.tgz",
+      "integrity": "sha512-FvnCJljyxhPM3gkRgWmxmDZyAQSiBQQWLI0A0VFL0K7W1oRUrPJSqNO0NvTnLkBcotdlp3lKvaT0JrnyRDkzOg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/uglify-js": {
@@ -3744,6 +3815,15 @@
         "@webassemblyjs/ast": "1.9.0",
         "@webassemblyjs/wast-parser": "1.9.0",
         "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.5.tgz",
+      "integrity": "sha512-V3BIhmY36fXZ1OtVcI9W+FxQqxVLsPKcNjWigIaa81dLC9IolJl5Mt4Cvhmr0flUnjSpTdrbMTSbXqYqV5dT6A==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/@xtuc/ieee754": {
@@ -4923,7 +5003,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
-      "optional": true,
+      "devOptional": true,
       "engines": {
         "node": ">=8"
       }
@@ -4935,6 +5015,41 @@
       "optional": true,
       "dependencies": {
         "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bl/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/bluebird": {
@@ -5397,6 +5512,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true
+    },
     "node_modules/check-types": {
       "version": "11.1.2",
       "resolved": "https://registry.npmjs.org/check-types/-/check-types-11.1.2.tgz",
@@ -5406,7 +5527,7 @@
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
       "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
-      "optional": true,
+      "devOptional": true,
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
@@ -5588,6 +5709,39 @@
         "node": ">=6"
       }
     },
+    "node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
+      "dependencies": {
+        "restore-cursor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.6.0.tgz",
+      "integrity": "sha512-t+4/y50K/+4xcCRosKkA7W4gTr1MySvLV0q+PxmG7FJ5g+66ChKurYjxBCjHggHH3HA5Hh9cy+lcUGWDqVH+4Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
+      "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/cliui": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
@@ -5596,6 +5750,15 @@
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/clsx": {
@@ -6532,9 +6695,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -6720,6 +6883,15 @@
       },
       "bin": {
         "which": "bin/which"
+      }
+    },
+    "node_modules/defaults": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+      "dev": true,
+      "dependencies": {
+        "clone": "^1.0.2"
       }
     },
     "node_modules/define-properties": {
@@ -8168,9 +8340,9 @@
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
     },
     "node_modules/events": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.2.0.tgz",
-      "integrity": "sha512-/46HWwbfCX2xTawVfkKLGxMifJYQBWMwY1mjywRtb4c9x8l5NP3KoJtnIOiL1hfdRkIuYhETxQlo62IF8tcnlg==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
       "engines": {
         "node": ">=0.8.x"
       }
@@ -8502,6 +8674,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/external-editor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "dev": true,
+      "dependencies": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/extglob": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
@@ -8626,6 +8812,21 @@
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
       "integrity": "sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw=="
+    },
+    "node_modules/figures": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+      "dev": true,
+      "dependencies": {
+        "escape-string-regexp": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.0",
@@ -9432,6 +9633,15 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
       "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
     },
+    "node_modules/graphql": {
+      "version": "15.5.3",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.5.3.tgz",
+      "integrity": "sha512-sM+jXaO5KinTui6lbK/7b7H/Knj9BpjGxZ+Ki35v7YbUJxxdBCUqNM0h3CRVU1ZF9t5lNiBzvBCSYPvIwxPOQA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
     "node_modules/grid-index": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/grid-index/-/grid-index-1.1.0.tgz",
@@ -9630,6 +9840,12 @@
       "bin": {
         "he": "bin/he"
       }
+    },
+    "node_modules/headers-utils": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/headers-utils/-/headers-utils-3.0.2.tgz",
+      "integrity": "sha512-xAxZkM1dRyGV2Ou5bzMxBPNLoRCjcX+ya7KSWybQD2KwLphxsapUVK6x/02o7f4VU6GPSXch9vNY2+gkU8tYWQ==",
+      "dev": true
     },
     "node_modules/hex-color-regex": {
       "version": "1.1.0",
@@ -10204,6 +10420,110 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
     },
+    "node_modules/inquirer": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.1.5.tgz",
+      "integrity": "sha512-G6/9xUqmt/r+UvufSyrPpt84NYwhKZ9jLsgMbQzlx804XErNupor8WQdBnBRrXmBfTPpuwf1sV+ss2ovjgdXIg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.1.1",
+        "cli-cursor": "^3.1.0",
+        "cli-width": "^3.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^3.0.0",
+        "lodash": "^4.17.21",
+        "mute-stream": "0.0.8",
+        "ora": "^5.4.1",
+        "run-async": "^2.4.0",
+        "rxjs": "^7.2.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "through": "^2.3.6"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/inquirer/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/inquirer/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/inquirer/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/inquirer/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/inquirer/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inquirer/node_modules/rxjs": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.3.0.tgz",
+      "integrity": "sha512-p2yuGIg9S1epc3vrjKf6iVb3RCaAYjYskkO+jHIaV0IjOPlJop4UnodOoFb2xeNwlguqLYvGw1b1McillYb5Gw==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "~2.1.0"
+      }
+    },
+    "node_modules/inquirer/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/internal-ip": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-4.3.0.tgz",
@@ -10292,7 +10612,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "optional": true,
+      "devOptional": true,
       "dependencies": {
         "binary-extensions": "^2.0.0"
       },
@@ -10454,6 +10774,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
@@ -10469,6 +10798,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-node-process": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.0.1.tgz",
+      "integrity": "sha512-5IcdXuf++TTNt3oGl9EBdkvndXA8gmc4bz/Y+mdEpWh3Mcn/+kOw6hI7LD5CocqJWMzeb0I0ClndRVNdEPuJXQ==",
+      "dev": true
     },
     "node_modules/is-number": {
       "version": "7.0.0",
@@ -10624,6 +10959,18 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/is-windows": {
       "version": "1.0.2",
@@ -12778,6 +13125,15 @@
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.1.tgz",
       "integrity": "sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg=="
     },
+    "node_modules/js-levenshtein": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
+      "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -13098,9 +13454,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash-es": {
       "version": "4.17.20",
@@ -13143,6 +13499,92 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
+    },
+    "node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-symbols/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/log-symbols/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/log-symbols/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/log-symbols/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/log-symbols/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/log-symbols/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/loglevel": {
       "version": "1.7.1",
@@ -13664,6 +14106,206 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
+    "node_modules/msw": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-0.35.0.tgz",
+      "integrity": "sha512-V7A6PqaS31F1k//fPS0OnO7vllfaqBUFsMEu3IpYixyWpiUInfyglodnbXhhtDyytkQikpkPZv8TZi/CvZzv/w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "@mswjs/cookies": "^0.1.6",
+        "@mswjs/interceptors": "^0.12.6",
+        "@open-draft/until": "^1.0.3",
+        "@types/cookie": "^0.4.1",
+        "@types/inquirer": "^7.3.3",
+        "@types/js-levenshtein": "^1.1.0",
+        "chalk": "^4.1.1",
+        "chokidar": "^3.4.2",
+        "cookie": "^0.4.1",
+        "graphql": "^15.5.1",
+        "headers-utils": "^3.0.2",
+        "inquirer": "^8.1.1",
+        "is-node-process": "^1.0.1",
+        "js-levenshtein": "^1.1.6",
+        "node-fetch": "^2.6.1",
+        "node-match-path": "^0.6.3",
+        "statuses": "^2.0.0",
+        "strict-event-emitter": "^0.2.0",
+        "type-fest": "^1.2.2",
+        "yargs": "^17.0.1"
+      },
+      "bin": {
+        "msw": "cli/index.js"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mswjs"
+      }
+    },
+    "node_modules/msw/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/msw/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/msw/node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/msw/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/msw/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/msw/node_modules/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/msw/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/msw/node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/msw/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/msw/node_modules/type-fest": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/msw/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/msw/node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/msw/node_modules/yargs": {
+      "version": "17.1.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.1.1.tgz",
+      "integrity": "sha512-c2k48R0PwKIqKhPMWjeiF6y2xY/gPMUlro0sgxqXpbOIohWiLNXWslsootttv7E1e73QPAMQSg5FeySbVcpsPQ==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/msw/node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/multicast-dns": {
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.2.3.tgz",
@@ -13685,6 +14327,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/murmurhash-js/-/murmurhash-js-1.0.0.tgz",
       "integrity": "sha1-sGJ44h/Gw3+lMTcysEEry2rhX1E="
+    },
+    "node_modules/mute-stream": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "dev": true
     },
     "node_modules/nan": {
       "version": "2.14.2",
@@ -13769,6 +14417,15 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/node-fetch": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.2.tgz",
+      "integrity": "sha512-aLoxToI6RfZ+0NOjmWAgn9+LEd30YCkJKFSyWacNZdEKTit/ZMcKjGkTRo8uWEsnIb/hfKecNPEbln02PdWbcA==",
+      "dev": true,
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
     "node_modules/node-forge": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
@@ -13838,6 +14495,12 @@
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
+    },
+    "node_modules/node-match-path": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/node-match-path/-/node-match-path-0.6.3.tgz",
+      "integrity": "sha512-fB1reOHKLRZCJMAka28hIxCwQLxGmd7WewOCBDYKpyA1KXi68A7vaGgdZAPhY2E6SXoYt3KqYCCvXLJ+O0Fu/Q==",
+      "dev": true
     },
     "node_modules/node-modules-regexp": {
       "version": "1.0.0",
@@ -14280,6 +14943,99 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/ora": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "dev": true,
+      "dependencies": {
+        "bl": "^4.1.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "is-unicode-supported": "^0.1.0",
+        "log-symbols": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ora/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/ora/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/ora/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/ora/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ora/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/original": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/original/-/original-1.0.2.tgz",
@@ -14292,6 +15048,21 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
       "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc="
+    },
+    "node_modules/os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/outvariant": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.2.1.tgz",
+      "integrity": "sha512-bcILvFkvpMXh66+Ubax/inxbKRyWTUiiFIW2DWkiS79wakrLGn3Ydy+GvukadiyfZjaL6C7YhIem4EZSM282wA==",
+      "dev": true
     },
     "node_modules/p-each-series": {
       "version": "2.2.0",
@@ -16831,7 +17602,7 @@
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
       "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
-      "optional": true,
+      "devOptional": true,
       "dependencies": {
         "picomatch": "^2.2.1"
       },
@@ -17299,6 +18070,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dev": true,
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ret": {
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
@@ -17470,6 +18254,15 @@
         "node": "6.* || >= 7.*"
       }
     },
+    "node_modules/run-async": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -17504,6 +18297,24 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
       "integrity": "sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q="
+    },
+    "node_modules/rxjs": {
+      "version": "6.6.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^1.9.0"
+      },
+      "engines": {
+        "npm": ">=2.0.0"
+      }
+    },
+    "node_modules/rxjs/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
     },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
@@ -18094,6 +18905,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.4.8",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.4.8.tgz",
+      "integrity": "sha512-edRH8mBKEWNVIVMKejNnuJxleqYE/ZSdcT8/Nem9/mmosx12pctd80s2Oy00KNZzrogMZS5mauK2/ymL1bvlvg==",
+      "dev": true
     },
     "node_modules/set-value": {
       "version": "2.0.1",
@@ -18874,6 +19691,15 @@
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
     },
+    "node_modules/strict-event-emitter": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.2.0.tgz",
+      "integrity": "sha512-zv7K2egoKwkQkZGEaH8m+i2D0XiKzx5jNsiSul6ja2IYFvil10A59Z9Y7PPAAe5OW53dQUf9CfsHKzjZzKkm1w==",
+      "dev": true,
+      "dependencies": {
+        "events": "^3.3.0"
+      }
+    },
     "node_modules/strict-uri-encode": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
@@ -19551,6 +20377,12 @@
       "resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",
       "integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA=="
     },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
     "node_modules/through2": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
@@ -19617,6 +20449,18 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
       "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA=="
+    },
+    "node_modules/tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "dependencies": {
+        "os-tmpdir": "~1.0.2"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
     },
     "node_modules/tmpl": {
       "version": "1.0.4",
@@ -20640,6 +21484,15 @@
       "integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
       "dependencies": {
         "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "node_modules/wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
+      "dev": true,
+      "dependencies": {
+        "defaults": "^1.0.3"
       }
     },
     "node_modules/web-vitals": {
@@ -24047,6 +24900,30 @@
         "gl-matrix": "^3.0.0"
       }
     },
+    "@mswjs/cookies": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-0.1.6.tgz",
+      "integrity": "sha512-A53XD5TOfwhpqAmwKdPtg1dva5wrng2gH5xMvklzbd9WLTSVU953eCRa8rtrrm6G7Cy60BOGsBRN89YQK0mlKA==",
+      "dev": true,
+      "requires": {
+        "@types/set-cookie-parser": "^2.4.0",
+        "set-cookie-parser": "^2.4.6"
+      }
+    },
+    "@mswjs/interceptors": {
+      "version": "0.12.7",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.12.7.tgz",
+      "integrity": "sha512-eGjZ3JRAt0Fzi5FgXiV/P3bJGj0NqsN7vBS0J0FO2AQRQ0jCKQS4lEFm4wvlSgKQNfeuc/Vz6d81VtU3Gkx/zg==",
+      "dev": true,
+      "requires": {
+        "@open-draft/until": "^1.0.3",
+        "@xmldom/xmldom": "^0.7.2",
+        "debug": "^4.3.2",
+        "headers-utils": "^3.0.2",
+        "outvariant": "^1.2.0",
+        "strict-event-emitter": "^0.2.0"
+      }
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz",
@@ -24085,6 +24962,12 @@
           "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
         }
       }
+    },
+    "@open-draft/until": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-1.0.3.tgz",
+      "integrity": "sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==",
+      "dev": true
     },
     "@pmmmwh/react-refresh-webpack-plugin": {
       "version": "0.4.3",
@@ -24631,6 +25514,12 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
+      "dev": true
+    },
     "@types/eslint": {
       "version": "7.2.6",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.6.tgz",
@@ -24672,6 +25561,16 @@
       "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-5.1.1.tgz",
       "integrity": "sha512-giAlZwstKbmvMk1OO7WXSj4OZ0keXAcl2TQq4LWHiiPH2ByaH7WeUzng+Qej8UPxxv+8lRTuouo0iaNDBuzIBA=="
     },
+    "@types/inquirer": {
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/@types/inquirer/-/inquirer-7.3.3.tgz",
+      "integrity": "sha512-HhxyLejTHMfohAuhRun4csWigAMjXTmRyiJTU1Y/I1xmggikFMkOUoMQRlFm+zQcPEGHSs3io/0FAmNZf8EymQ==",
+      "dev": true,
+      "requires": {
+        "@types/through": "*",
+        "rxjs": "^6.4.0"
+      }
+    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
@@ -24702,6 +25601,12 @@
         "jest-diff": "^26.0.0",
         "pretty-format": "^26.0.0"
       }
+    },
+    "@types/js-levenshtein": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@types/js-levenshtein/-/js-levenshtein-1.1.0.tgz",
+      "integrity": "sha512-14t0v1ICYRtRVcHASzes0v/O+TIeASb8aD55cWF1PidtInhFWSXcmhzhHqGjUWf9SUq1w70cvd1cWKUULubAfQ==",
+      "dev": true
     },
     "@types/json-schema": {
       "version": "7.0.7",
@@ -24759,6 +25664,15 @@
         "@types/node": "*"
       }
     },
+    "@types/set-cookie-parser": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@types/set-cookie-parser/-/set-cookie-parser-2.4.1.tgz",
+      "integrity": "sha512-N0IWe4vT1w5IOYdN9c9PNpQniHS+qe25W4tj4vfhJDJ9OkvA/YA55YUhaC+HNmMMeLlOSnBW9UMno0qlt5xu3Q==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/source-list-map": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/@types/source-list-map/-/source-list-map-0.1.2.tgz",
@@ -24781,6 +25695,15 @@
       "dev": true,
       "requires": {
         "@types/jest": "*"
+      }
+    },
+    "@types/through": {
+      "version": "0.0.30",
+      "resolved": "https://registry.npmjs.org/@types/through/-/through-0.0.30.tgz",
+      "integrity": "sha512-FvnCJljyxhPM3gkRgWmxmDZyAQSiBQQWLI0A0VFL0K7W1oRUrPJSqNO0NvTnLkBcotdlp3lKvaT0JrnyRDkzOg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
       }
     },
     "@types/uglify-js": {
@@ -25080,6 +26003,12 @@
         "@webassemblyjs/wast-parser": "1.9.0",
         "@xtuc/long": "4.2.2"
       }
+    },
+    "@xmldom/xmldom": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.5.tgz",
+      "integrity": "sha512-V3BIhmY36fXZ1OtVcI9W+FxQqxVLsPKcNjWigIaa81dLC9IolJl5Mt4Cvhmr0flUnjSpTdrbMTSbXqYqV5dT6A==",
+      "dev": true
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",
@@ -25999,7 +26928,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
-      "optional": true
+      "devOptional": true
     },
     "bindings": {
       "version": "1.5.0",
@@ -26008,6 +26937,29 @@
       "optional": true,
       "requires": {
         "file-uri-to-path": "1.0.0"
+      }
+    },
+    "bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "requires": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
+          }
+        }
       }
     },
     "bluebird": {
@@ -26388,6 +27340,12 @@
       "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
       "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw=="
     },
+    "chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true
+    },
     "check-types": {
       "version": "11.1.2",
       "resolved": "https://registry.npmjs.org/check-types/-/check-types-11.1.2.tgz",
@@ -26397,7 +27355,7 @@
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
       "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
-      "optional": true,
+      "devOptional": true,
       "requires": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
@@ -26545,6 +27503,27 @@
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
       "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="
     },
+    "cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "^3.1.0"
+      }
+    },
+    "cli-spinners": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.6.0.tgz",
+      "integrity": "sha512-t+4/y50K/+4xcCRosKkA7W4gTr1MySvLV0q+PxmG7FJ5g+66ChKurYjxBCjHggHH3HA5Hh9cy+lcUGWDqVH+4Q==",
+      "dev": true
+    },
+    "cli-width": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
+      "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
+      "dev": true
+    },
     "cliui": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
@@ -26554,6 +27533,12 @@
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^6.2.0"
       }
+    },
+    "clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+      "dev": true
     },
     "clsx": {
       "version": "1.1.1",
@@ -27302,9 +28287,9 @@
       }
     },
     "debug": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
       "requires": {
         "ms": "2.1.2"
       }
@@ -27439,6 +28424,15 @@
             "isexe": "^2.0.0"
           }
         }
+      }
+    },
+    "defaults": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+      "dev": true,
+      "requires": {
+        "clone": "^1.0.2"
       }
     },
     "define-properties": {
@@ -28547,9 +29541,9 @@
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
     },
     "events": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.2.0.tgz",
-      "integrity": "sha512-/46HWwbfCX2xTawVfkKLGxMifJYQBWMwY1mjywRtb4c9x8l5NP3KoJtnIOiL1hfdRkIuYhETxQlo62IF8tcnlg=="
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
     },
     "eventsource": {
       "version": "1.0.7",
@@ -28827,6 +29821,17 @@
         "is-extendable": "^1.0.1"
       }
     },
+    "external-editor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "dev": true,
+      "requires": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      }
+    },
     "extglob": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
@@ -28932,6 +29937,15 @@
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
       "integrity": "sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw=="
+    },
+    "figures": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5"
+      }
     },
     "file-entry-cache": {
       "version": "6.0.0",
@@ -29564,6 +30578,12 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
       "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
     },
+    "graphql": {
+      "version": "15.5.3",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.5.3.tgz",
+      "integrity": "sha512-sM+jXaO5KinTui6lbK/7b7H/Knj9BpjGxZ+Ki35v7YbUJxxdBCUqNM0h3CRVU1ZF9t5lNiBzvBCSYPvIwxPOQA==",
+      "dev": true
+    },
     "grid-index": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/grid-index/-/grid-index-1.1.0.tgz",
@@ -29708,6 +30728,12 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
+    },
+    "headers-utils": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/headers-utils/-/headers-utils-3.0.2.tgz",
+      "integrity": "sha512-xAxZkM1dRyGV2Ou5bzMxBPNLoRCjcX+ya7KSWybQD2KwLphxsapUVK6x/02o7f4VU6GPSXch9vNY2+gkU8tYWQ==",
+      "dev": true
     },
     "hex-color-regex": {
       "version": "1.1.0",
@@ -30181,6 +31207,88 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
     },
+    "inquirer": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.1.5.tgz",
+      "integrity": "sha512-G6/9xUqmt/r+UvufSyrPpt84NYwhKZ9jLsgMbQzlx804XErNupor8WQdBnBRrXmBfTPpuwf1sV+ss2ovjgdXIg==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.1.1",
+        "cli-cursor": "^3.1.0",
+        "cli-width": "^3.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^3.0.0",
+        "lodash": "^4.17.21",
+        "mute-stream": "0.0.8",
+        "ora": "^5.4.1",
+        "run-async": "^2.4.0",
+        "rxjs": "^7.2.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "through": "^2.3.6"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "rxjs": {
+          "version": "7.3.0",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.3.0.tgz",
+          "integrity": "sha512-p2yuGIg9S1epc3vrjKf6iVb3RCaAYjYskkO+jHIaV0IjOPlJop4UnodOoFb2xeNwlguqLYvGw1b1McillYb5Gw==",
+          "dev": true,
+          "requires": {
+            "tslib": "~2.1.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "internal-ip": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-4.3.0.tgz",
@@ -30245,7 +31353,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "optional": true,
+      "devOptional": true,
       "requires": {
         "binary-extensions": "^2.0.0"
       }
@@ -30353,6 +31461,12 @@
         "is-extglob": "^2.1.1"
       }
     },
+    "is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "dev": true
+    },
     "is-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
@@ -30362,6 +31476,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
       "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w=="
+    },
+    "is-node-process": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.0.1.tgz",
+      "integrity": "sha512-5IcdXuf++TTNt3oGl9EBdkvndXA8gmc4bz/Y+mdEpWh3Mcn/+kOw6hI7LD5CocqJWMzeb0I0ClndRVNdEPuJXQ==",
+      "dev": true
     },
     "is-number": {
       "version": "7.0.0",
@@ -30466,6 +31586,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true
     },
     "is-windows": {
       "version": "1.0.2",
@@ -32047,6 +33173,12 @@
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.1.tgz",
       "integrity": "sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg=="
     },
+    "js-levenshtein": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
+      "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
+      "dev": true
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -32302,9 +33434,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash-es": {
       "version": "4.17.20",
@@ -32347,6 +33479,67 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
+    },
+    "log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
     },
     "loglevel": {
       "version": "1.7.1",
@@ -32758,6 +33951,152 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
+    "msw": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-0.35.0.tgz",
+      "integrity": "sha512-V7A6PqaS31F1k//fPS0OnO7vllfaqBUFsMEu3IpYixyWpiUInfyglodnbXhhtDyytkQikpkPZv8TZi/CvZzv/w==",
+      "dev": true,
+      "requires": {
+        "@mswjs/cookies": "^0.1.6",
+        "@mswjs/interceptors": "^0.12.6",
+        "@open-draft/until": "^1.0.3",
+        "@types/cookie": "^0.4.1",
+        "@types/inquirer": "^7.3.3",
+        "@types/js-levenshtein": "^1.1.0",
+        "chalk": "^4.1.1",
+        "chokidar": "^3.4.2",
+        "cookie": "^0.4.1",
+        "graphql": "^15.5.1",
+        "headers-utils": "^3.0.2",
+        "inquirer": "^8.1.1",
+        "is-node-process": "^1.0.1",
+        "js-levenshtein": "^1.1.6",
+        "node-fetch": "^2.6.1",
+        "node-match-path": "^0.6.3",
+        "statuses": "^2.0.0",
+        "strict-event-emitter": "^0.2.0",
+        "type-fest": "^1.2.2",
+        "yargs": "^17.0.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "cliui": {
+          "version": "7.0.4",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+          "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^7.0.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "cookie": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+          "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "statuses": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+          "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "type-fest": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+          "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+          "dev": true
+        },
+        "wrap-ansi": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "y18n": {
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+          "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+          "dev": true
+        },
+        "yargs": {
+          "version": "17.1.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.1.1.tgz",
+          "integrity": "sha512-c2k48R0PwKIqKhPMWjeiF6y2xY/gPMUlro0sgxqXpbOIohWiLNXWslsootttv7E1e73QPAMQSg5FeySbVcpsPQ==",
+          "dev": true,
+          "requires": {
+            "cliui": "^7.0.2",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.0",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^20.2.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "20.2.9",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+          "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+          "dev": true
+        }
+      }
+    },
     "multicast-dns": {
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.2.3.tgz",
@@ -32776,6 +34115,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/murmurhash-js/-/murmurhash-js-1.0.0.tgz",
       "integrity": "sha1-sGJ44h/Gw3+lMTcysEEry2rhX1E="
+    },
+    "mute-stream": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "dev": true
     },
     "nan": {
       "version": "2.14.2",
@@ -32848,6 +34193,12 @@
         "tslib": "^2.0.3"
       }
     },
+    "node-fetch": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.2.tgz",
+      "integrity": "sha512-aLoxToI6RfZ+0NOjmWAgn9+LEd30YCkJKFSyWacNZdEKTit/ZMcKjGkTRo8uWEsnIb/hfKecNPEbln02PdWbcA==",
+      "dev": true
+    },
     "node-forge": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
@@ -32916,6 +34267,12 @@
           }
         }
       }
+    },
+    "node-match-path": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/node-match-path/-/node-match-path-0.6.3.tgz",
+      "integrity": "sha512-fB1reOHKLRZCJMAka28hIxCwQLxGmd7WewOCBDYKpyA1KXi68A7vaGgdZAPhY2E6SXoYt3KqYCCvXLJ+O0Fu/Q==",
+      "dev": true
     },
     "node-modules-regexp": {
       "version": "1.0.0",
@@ -33246,6 +34603,74 @@
         "word-wrap": "^1.2.3"
       }
     },
+    "ora": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "dev": true,
+      "requires": {
+        "bl": "^4.1.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "is-unicode-supported": "^0.1.0",
+        "log-symbols": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "original": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/original/-/original-1.0.2.tgz",
@@ -33258,6 +34683,18 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
       "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc="
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
+    },
+    "outvariant": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.2.1.tgz",
+      "integrity": "sha512-bcILvFkvpMXh66+Ubax/inxbKRyWTUiiFIW2DWkiS79wakrLGn3Ydy+GvukadiyfZjaL6C7YhIem4EZSM282wA==",
+      "dev": true
     },
     "p-each-series": {
       "version": "2.2.0",
@@ -35288,7 +36725,7 @@
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
       "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
-      "optional": true,
+      "devOptional": true,
       "requires": {
         "picomatch": "^2.2.1"
       }
@@ -35651,6 +37088,16 @@
         }
       }
     },
+    "restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dev": true,
+      "requires": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
     "ret": {
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
@@ -35792,6 +37239,12 @@
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
       "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA=="
     },
+    "run-async": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+      "dev": true
+    },
     "run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -35812,6 +37265,23 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
       "integrity": "sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q="
+    },
+    "rxjs": {
+      "version": "6.6.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.9.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        }
+      }
     },
     "safe-buffer": {
       "version": "5.1.2",
@@ -36284,6 +37754,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+    },
+    "set-cookie-parser": {
+      "version": "2.4.8",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.4.8.tgz",
+      "integrity": "sha512-edRH8mBKEWNVIVMKejNnuJxleqYE/ZSdcT8/Nem9/mmosx12pctd80s2Oy00KNZzrogMZS5mauK2/ymL1bvlvg==",
+      "dev": true
     },
     "set-value": {
       "version": "2.0.1",
@@ -36954,6 +38430,15 @@
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
     },
+    "strict-event-emitter": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.2.0.tgz",
+      "integrity": "sha512-zv7K2egoKwkQkZGEaH8m+i2D0XiKzx5jNsiSul6ja2IYFvil10A59Z9Y7PPAAe5OW53dQUf9CfsHKzjZzKkm1w==",
+      "dev": true,
+      "requires": {
+        "events": "^3.3.0"
+      }
+    },
     "strict-uri-encode": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
@@ -37445,6 +38930,12 @@
       "resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",
       "integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA=="
     },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
     "through2": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
@@ -37510,6 +39001,15 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
       "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA=="
+    },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "~1.0.2"
+      }
     },
     "tmpl": {
       "version": "1.0.4",
@@ -38337,6 +39837,15 @@
       "integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
       "requires": {
         "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
+      "dev": true,
+      "requires": {
+        "defaults": "^1.0.3"
       }
     },
     "web-vitals": {

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -29,6 +29,7 @@
         "@typescript-eslint/parser": "^4.15.1",
         "eslint-config-prettier": "^7.2.0",
         "eslint-plugin-prettier": "^3.3.1",
+        "eslint-plugin-react-hooks": "^4.2.0",
         "msw": "^0.35.0",
         "prettier": "^2.2.1",
         "typescript": "^4.1.5"

--- a/web/package.json
+++ b/web/package.json
@@ -36,7 +36,7 @@
       "prettier/prettier": "warn"
     }
   },
-  "eslintIgnore":[
+  "eslintIgnore": [
     "build"
   ],
   "browserslist": {
@@ -58,6 +58,7 @@
     "@typescript-eslint/parser": "^4.15.1",
     "eslint-config-prettier": "^7.2.0",
     "eslint-plugin-prettier": "^3.3.1",
+    "msw": "^0.35.0",
     "prettier": "^2.2.1",
     "typescript": "^4.1.5"
   }

--- a/web/package.json
+++ b/web/package.json
@@ -30,6 +30,7 @@
     "extends": [
       "react-app",
       "react-app/jest",
+      "plugin:react-hooks/recommended",
       "plugin:prettier/recommended"
     ],
     "rules": {
@@ -58,6 +59,7 @@
     "@typescript-eslint/parser": "^4.15.1",
     "eslint-config-prettier": "^7.2.0",
     "eslint-plugin-prettier": "^3.3.1",
+    "eslint-plugin-react-hooks": "^4.2.0",
     "msw": "^0.35.0",
     "prettier": "^2.2.1",
     "typescript": "^4.1.5"

--- a/web/src/api.util.js
+++ b/web/src/api.util.js
@@ -35,3 +35,12 @@ export const apiUrlCollectionById = (collectionId) =>
  * @returns {string}
  */
 export const apiUrlDevices = () => apiUrl("devices");
+
+/**
+ * Removes the protocol from a url so that it is an empty protocol.
+ * This prevents mixed content errors (https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content), 
+ * when one environment is http and the other is https
+ * @param {string} link
+ * @returns {string} the link in the form "//domain.io"
+ */
+export const emptyProtocol = (link) => link.replace(/^(https?|ftp):/, "");

--- a/web/src/api.util.js
+++ b/web/src/api.util.js
@@ -38,7 +38,7 @@ export const apiUrlDevices = () => apiUrl("devices");
 
 /**
  * Removes the protocol from a url so that it is an empty protocol.
- * This prevents mixed content errors (https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content), 
+ * This prevents mixed content errors (https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content),
  * when one environment is http and the other is https
  * @param {string} link
  * @returns {string} the link in the form "//domain.io"

--- a/web/src/api.util.test.js
+++ b/web/src/api.util.test.js
@@ -7,21 +7,21 @@ import {
 } from "./api.util";
 
 it("should create the base api url with an endpoint", () => {
-  expect(apiUrl("path")).toEqual("//api.lvh.me/path");
+  expect(apiUrl("path")).toEqual("http://api.lvh.me/path");
 });
 
 it("should create the url to get all collections", () => {
-  expect(apiUrlCollections()).toEqual("//api.lvh.me/collection");
+  expect(apiUrlCollections()).toEqual("http://api.lvh.me/collection");
 });
 
 it("should create the url to get a collection by its ID", () => {
   expect(apiUrlCollectionById(1)).toEqual(
-    "//api.lvh.me/collection/1/data"
+    "http://api.lvh.me/collection/1/data"
   );
 });
 
 it("should create the url to get all devices", () => {
-  expect(apiUrlDevices()).toEqual("//api.lvh.me/devices");
+  expect(apiUrlDevices()).toEqual("http://api.lvh.me/devices");
 });
 
 describe("empty protocol", () => {

--- a/web/src/api.util.test.js
+++ b/web/src/api.util.test.js
@@ -3,22 +3,41 @@ import {
   apiUrlCollections,
   apiUrlCollectionById,
   apiUrlDevices,
+  emptyProtocol,
 } from "./api.util";
 
 it("should create the base api url with an endpoint", () => {
-  expect(apiUrl("path")).toEqual("http://api.lvh.me/path");
+  expect(apiUrl("path")).toEqual("//api.lvh.me/path");
 });
 
 it("should create the url to get all collections", () => {
-  expect(apiUrlCollections()).toEqual("http://api.lvh.me/collection");
+  expect(apiUrlCollections()).toEqual("//api.lvh.me/collection");
 });
 
 it("should create the url to get a collection by its ID", () => {
   expect(apiUrlCollectionById(1)).toEqual(
-    "http://api.lvh.me/collection/1/data"
+    "//api.lvh.me/collection/1/data"
   );
 });
 
 it("should create the url to get all devices", () => {
-  expect(apiUrlDevices()).toEqual("http://api.lvh.me/devices");
+  expect(apiUrlDevices()).toEqual("//api.lvh.me/devices");
+});
+
+describe("empty protocol", () => {
+  const emptyProtocolLink = "//example.com";
+  it("should remove http", () =>
+    expect(emptyProtocol(`http:${emptyProtocolLink}`)).toEqual(
+      emptyProtocolLink
+    ));
+
+  it("should remove https", () =>
+    expect(emptyProtocol(`https:${emptyProtocolLink}`)).toEqual(
+      emptyProtocolLink
+    ));
+
+  it("should remove ftp", () =>
+    expect(emptyProtocol(`ftp:${emptyProtocolLink}`)).toEqual(
+      emptyProtocolLink
+    ));
 });

--- a/web/src/components/map/index.js
+++ b/web/src/components/map/index.js
@@ -8,7 +8,6 @@ import { MapMenu } from "./menu";
 
 import {
   BLANK_ACTIVE_ID,
-  BLANK_ACTIVE_COLLECTION,
   getCollectionsOnDate,
   getFirstCollection,
   fallbackPollutants,
@@ -55,7 +54,11 @@ export const Map = () => {
           source
         );
         setCollectionsOnDate(localCollectionsOnDate);
-        const { id, collection_files: [localGpsFile, localDustrakFile], starts_at} = getFirstCollection(localCollectionsOnDate);
+        const {
+          id,
+          collection_files: [localGpsFile, localDustrakFile],
+          starts_at,
+        } = getFirstCollection(localCollectionsOnDate);
         setActiveId(id);
         setActiveStartsAt(starts_at);
         if (id !== BLANK_ACTIVE_ID) setIsLoadingPollutants(true);
@@ -134,13 +137,12 @@ export const Map = () => {
       setFormattedDate(newMapDate.format("YYYY-MM-DD"));
       setCollectionsOnDate([]);
 
-
       setActiveId(BLANK_ACTIVE_ID);
       setActiveStartsAt(BLANK_ACTIVE_STARTS_AT);
 
       setGpsFile("");
       setDustrakFile("");
-      setGpsFileUrl ("");
+      setGpsFileUrl("");
       setDustrakFileUrl("");
 
       setPollutants([]);
@@ -158,10 +160,14 @@ export const Map = () => {
   const changeActiveCollection = (pendingCollection) => {
     //guard against double click
     if (pendingCollection.id) {
-      const {id, collection_files: [localGpsFile, localDustrakFile], starts_at} = pendingCollection;
+      const {
+        id,
+        collection_files: [localGpsFile, localDustrakFile],
+        starts_at,
+      } = pendingCollection;
       setActiveId(id);
       setActiveStartsAt(starts_at);
-      
+
       setGpsFile(localGpsFile);
       setDustrakFile(localDustrakFile);
       setGpsFileUrl("");

--- a/web/src/components/map/index.js
+++ b/web/src/components/map/index.js
@@ -35,7 +35,7 @@ export const Map = () => {
   const [activeId, setActiveId] = useState(BLANK_ACTIVE_ID);
   const [activeStartsAt, setActiveStartsAt] = useState(BLANK_ACTIVE_STARTS_AT);
   // the database endpoint for file metadata
-  const [gpsFile, setGpsFile] = useState(""); 
+  const [gpsFile, setGpsFile] = useState("");
   const [dustrakFile, setDustrakFile] = useState("");
   // the direct download link for the file itself
   const [gpsFileUrl, setGpsFileUrl] = useState("");

--- a/web/src/components/map/index.js
+++ b/web/src/components/map/index.js
@@ -13,10 +13,11 @@ import {
   fallbackPollutants,
   getPollutantsByCollectionId,
   getCollectionFileByLink,
-  swapProtocol,
   BLANK_ACTIVE_STARTS_AT,
   THROWN_CODE,
 } from "./utils";
+
+import { emptyProtocol } from "../../api.util";
 
 import { Grid } from "../ui";
 
@@ -103,14 +104,14 @@ export const Map = () => {
           { file: localGpsFile, thrownCode: thrownCodeGps },
           { file: localDustrakFile, thrownCode: thrownCodeDustrak },
         ] = await Promise.all([
-          getCollectionFileByLink(swapProtocol(gpsFile), source),
-          getCollectionFileByLink(swapProtocol(dustrakFile), source),
+          getCollectionFileByLink(emptyProtocol(gpsFile), source),
+          getCollectionFileByLink(emptyProtocol(dustrakFile), source),
         ]);
 
         if (thrownCodeGps === THROWN_CODE.NONE)
-          setGpsFileUrl(swapProtocol(localGpsFile.file));
+          setGpsFileUrl(emptyProtocol(localGpsFile.file));
         if (thrownCodeDustrak === THROWN_CODE.NONE)
-          setDustrakFileUrl(swapProtocol(localDustrakFile.file));
+          setDustrakFileUrl(emptyProtocol(localDustrakFile.file));
       }
     })();
 

--- a/web/src/components/map/index.js
+++ b/web/src/components/map/index.js
@@ -140,6 +140,9 @@ export const Map = () => {
       const newMapDate = moment(rawDate.toISOString());
       setMapDate(newMapDate);
       setFormattedDate(newMapDate.format("YYYY-MM-DD"));
+      setActiveId(-1);
+      setActiveCollection({});
+      setCollectionsOnDate([]);
     }
   };
 

--- a/web/src/components/map/index.js
+++ b/web/src/components/map/index.js
@@ -34,8 +34,10 @@ export const Map = () => {
   const [collectionsOnDate, setCollectionsOnDate] = useState([]);
   const [activeId, setActiveId] = useState(BLANK_ACTIVE_ID);
   const [activeStartsAt, setActiveStartsAt] = useState(BLANK_ACTIVE_STARTS_AT);
-  const [gpsFile, setGpsFile] = useState("");
+  // the database endpoint for file metadata
+  const [gpsFile, setGpsFile] = useState(""); 
   const [dustrakFile, setDustrakFile] = useState("");
+  // the direct download link for the file itself
   const [gpsFileUrl, setGpsFileUrl] = useState("");
   const [dustrakFileUrl, setDustrakFileUrl] = useState("");
   const [pollutants, setPollutants] = useState([]);
@@ -68,7 +70,6 @@ export const Map = () => {
         } = getFirstCollection(localCollectionsOnDate);
         setActiveId(id);
         setActiveStartsAt(starts_at);
-        // if (id !== BLANK_ACTIVE_ID) setIsLoadingPollutants(true);
         if (localGpsFile && localDustrakFile) {
           setGpsFile(localGpsFile);
           setDustrakFile(localDustrakFile);
@@ -190,7 +191,6 @@ export const Map = () => {
         collection_files: [localGpsFile, localDustrakFile],
         starts_at,
       } = collection;
-      // setIsLoadingPollutants(true);
       setActiveId(id);
       setActiveStartsAt(starts_at);
 

--- a/web/src/components/map/index.js
+++ b/web/src/components/map/index.js
@@ -10,7 +10,7 @@ import {
   BLANK_ACTIVE_ID,
   getCollectionsOnDate,
   getFirstCollection,
-  fallbackPollutants,
+  parsePollutants,
   getPollutantsByCollectionId,
   getCollectionFileByLink,
   BLANK_ACTIVE_STARTS_AT,
@@ -84,7 +84,7 @@ export const Map = () => {
           thrownCode,
         } = await getPollutantsByCollectionId(activeId, source);
         if (thrownCode === THROWN_CODE.NONE)
-          setPollutants(fallbackPollutants(rawPollutants));
+          setPollutants(parsePollutants(rawPollutants));
         if (thrownCode !== THROWN_CODE.CANCELED) setIsLoadingPollutants(false);
       } else {
         setIsLoadingPollutants(false);
@@ -151,7 +151,6 @@ export const Map = () => {
   /**
    * Load a new collection from the current date
    * @param {HTMLButtonEvent} event
-   * @modifies {api} Cancel any pending loads
    * @modifies {shouldLoadCollections}
    * @modifies {collection}
    * @modifies {cancelTokenSource}

--- a/web/src/components/map/index.js
+++ b/web/src/components/map/index.js
@@ -94,9 +94,9 @@ export const Map = () => {
       }
     })();
     return () => {
-      setIsLoadingPollutants(false)
+      setIsLoadingPollutants(false);
       source.cancel();
-    }
+    };
   }, [activeId]);
 
   /**
@@ -105,8 +105,8 @@ export const Map = () => {
   useEffect(() => {
     const source = axios.CancelToken.source();
     (async () => {
-      console.log('dustrakFile', dustrakFile);
-      console.log('gpsFile', gpsFile);
+      console.log("dustrakFile", dustrakFile);
+      console.log("gpsFile", gpsFile);
       if (gpsFile || dustrakFile) {
         try {
           const [localGpsFile, localDustrakFile] = await Promise.all([

--- a/web/src/components/map/index.js
+++ b/web/src/components/map/index.js
@@ -81,19 +81,22 @@ export const Map = () => {
     (async () => {
       if (activeId !== BLANK_ACTIVE_ID) {
         try {
+          setIsLoadingPollutants(true);
           const pendingPollutantValues = await getPollutantsByCollectionId(
             activeId,
             source
           );
           setPollutants(fallbackPollutants(pendingPollutantValues));
+          setIsLoadingPollutants(false);
         } catch (thrown) {
           canceledPollutantsMessage(thrown);
-        } finally {
-          setIsLoadingPollutants(false);
         }
       }
     })();
-    return source.cancel;
+    return () => {
+      setIsLoadingPollutants(false)
+      source.cancel();
+    }
   }, [activeId]);
 
   /**
@@ -102,7 +105,9 @@ export const Map = () => {
   useEffect(() => {
     const source = axios.CancelToken.source();
     (async () => {
-      if (gpsFile && dustrakFile) {
+      console.log('dustrakFile', dustrakFile);
+      console.log('gpsFile', gpsFile);
+      if (gpsFile || dustrakFile) {
         try {
           const [localGpsFile, localDustrakFile] = await Promise.all([
             getCollectionFileByLink(swapProtocol(gpsFile), source),
@@ -165,16 +170,16 @@ export const Map = () => {
         collection_files: [localGpsFile, localDustrakFile],
         starts_at,
       } = pendingCollection;
+      // setIsLoadingPollutants(true);
       setActiveId(id);
       setActiveStartsAt(starts_at);
 
       setGpsFile(localGpsFile);
       setDustrakFile(localDustrakFile);
       setGpsFileUrl("");
-      setDustrakFile("");
+      setDustrakFileUrl("");
 
       setPollutants([]);
-      setIsLoadingPollutants(true);
     }
   };
 

--- a/web/src/components/map/index.js
+++ b/web/src/components/map/index.js
@@ -49,27 +49,25 @@ export const Map = () => {
   useEffect(() => {
     const source = axios.CancelToken.source();
     (async () => {
-      try {
-        const localCollectionsOnDate = await getCollectionsOnDate(
+        const {collectionsOnDate: localCollectionsOnDate, thrownCode} = await getCollectionsOnDate(
           formattedDate,
           source
         );
-        setCollectionsOnDate(localCollectionsOnDate);
-        const {
-          id,
-          collection_files: [localGpsFile, localDustrakFile],
-          starts_at,
-        } = getFirstCollection(localCollectionsOnDate);
-        setActiveId(id);
-        setActiveStartsAt(starts_at);
-        if (id !== BLANK_ACTIVE_ID) setIsLoadingPollutants(true);
-        if (localGpsFile && localDustrakFile) {
-          setGpsFile(localGpsFile);
-          setDustrakFile(localDustrakFile);
+        if(thrownCode === THROWN_CODE.NONE) {
+          setCollectionsOnDate(localCollectionsOnDate);
+          const {
+            id,
+            collection_files: [localGpsFile, localDustrakFile],
+            starts_at,
+          } = getFirstCollection(localCollectionsOnDate);
+          setActiveId(id);
+          setActiveStartsAt(starts_at);
+          if (id !== BLANK_ACTIVE_ID) setIsLoadingPollutants(true);
+          if (localGpsFile && localDustrakFile) {
+            setGpsFile(localGpsFile);
+            setDustrakFile(localDustrakFile);
+          }
         }
-      } catch (thrown) {
-        canceledCollectionsMessage(thrown);
-      }
     })();
     return source.cancel;
   }, [formattedDate]);

--- a/web/src/components/map/index.js
+++ b/web/src/components/map/index.js
@@ -27,7 +27,9 @@ export const Map = () => {
   const location = useLocation(); // location for the url
   const initialDate = moment(location?.state?.date) || moment(); // Date either from upload or current day
   const [mapDate, setMapDate] = useState(initialDate);
-  const [formattedDate, setFormattedDate] = useState(initialDate.format("YYYY-MM-DD"))
+  const [formattedDate, setFormattedDate] = useState(
+    initialDate.format("YYYY-MM-DD")
+  );
   const [collectionsOnDate, setCollectionsOnDate] = useState([]);
   const [activeCollection, setActiveCollection] = useState({});
   const [activeId, setActiveId] = useState(-1);
@@ -50,17 +52,17 @@ export const Map = () => {
           source
         );
         setCollectionsOnDate(pendingCollectionsOnDate);
-        const fallbackActive = fallbackCollection(pendingCollectionsOnDate)
+        const fallbackActive = fallbackCollection(pendingCollectionsOnDate);
         const { id, collection_files: collectionFiles } = fallbackActive;
         console.log(collectionFiles);
-        const [ activeGpsFile, activeDustrakFile] = collectionFiles;
+        const [activeGpsFile, activeDustrakFile] = collectionFiles;
         setActiveCollection(fallbackActive);
         setActiveId(id);
-        if(id && id > -1) setIsPendingResponse(true);
-        if(activeGpsFile && activeDustrakFile){
+        if (id && id > -1) setIsPendingResponse(true);
+        if (activeGpsFile && activeDustrakFile) {
           setGpsFile(activeGpsFile);
           setDustrakFile(activeDustrakFile);
-        };
+        }
       } catch (thrown) {
         canceledCollectionsMessage(thrown);
       }
@@ -74,7 +76,7 @@ export const Map = () => {
   useEffect(() => {
     const source = axios.CancelToken.source();
     (async () => {
-      if(activeId && activeId > -1){
+      if (activeId && activeId > -1) {
         try {
           const pendingPollutantValues = await getPollutantsByCollectionId(
             activeId,
@@ -83,7 +85,7 @@ export const Map = () => {
           setPollutants(fallbackPollutants(pendingPollutantValues));
         } catch (thrown) {
           canceledPollutantsMessage(thrown);
-        } finally{
+        } finally {
           setIsPendingResponse(false);
         }
       }
@@ -92,12 +94,12 @@ export const Map = () => {
   }, [activeId]);
 
   /**
- * Call the api to load the urls for gps+dustrak source files of a collection
- */
+   * Call the api to load the urls for gps+dustrak source files of a collection
+   */
   useEffect(() => {
     const source = axios.CancelToken.source();
     (async () => {
-      if(gpsFile && dustrakFile){
+      if (gpsFile && dustrakFile) {
         try {
           const [pendingGpsFile, pendingDustrakFile] = await Promise.all([
             getCollectionFileByLink(swapProtocol(gpsFile), source),
@@ -135,7 +137,7 @@ export const Map = () => {
     // guard against double click
     if (rawDate) {
       clearActiveCollection();
-      const newMapDate = moment(rawDate.toISOString())
+      const newMapDate = moment(rawDate.toISOString());
       setMapDate(newMapDate);
       setFormattedDate(newMapDate.format("YYYY-MM-DD"));
     }

--- a/web/src/components/map/menu.js
+++ b/web/src/components/map/menu.js
@@ -6,23 +6,25 @@ import "react-semantic-ui-datepickers/dist/react-semantic-ui-datepickers.css";
 import SemanticDatepicker from "react-semantic-ui-datepickers";
 import { Container, List, WarningMessage } from "../ui";
 import "./menu.css";
+import { BLANK_ACTIVE_ID } from "./utils";
 
 /**
  * Menu for Dates and Collections to map
  * @property {moment} mapDate Day viewed on mapped
  * @property {Array<Collection>} collectionsOnDate Collections from the viewed day
  * @property {Collection} activeCollection collection actively viewed on map
- * @property {function} stageLoadingDate start the process to load collections on date
- * @property {function} stageLoadingCollection start the process to load pollutants from a colletion
+ * @property {function} changeMapDate start the process to load collections on date
+ * @property {function} changeActiveCollection start the process to load pollutants from a colletion
  * @property {string} gpsFileUrl url to a gps file
  * @property {string} dustrakFileUrl url to a dustrak file
  */
 export const MapMenu = ({
   mapDate,
   collectionsOnDate,
-  activeCollection,
-  stageLoadingDate,
-  stageLoadingCollection,
+  activeId,
+  activeStartsAt,
+  changeMapDate,
+  changeActiveCollection,
   gpsFileUrl,
   dustrakFileUrl,
 }) => {
@@ -30,16 +32,16 @@ export const MapMenu = ({
    * From the collections, composed React Components to display each collection
    * Exclude the active collection
    */
-  const collectionsDisplay = collectionsOnDate
-    .filter((eachCollection) => eachCollection.id !== activeCollection.id)
-    .map((eachCollection) => {
-      const id = eachCollection.id;
-      const startsAt = eachCollection.starts_at;
+  const otherCollectionsDisplay = collectionsOnDate
+    .filter((collection) => collection.id !== activeId)
+    .map((collection) => {
+      const id = collection.id;
+      const startsAt = collection.starts_at;
       return (
         <List.Item
           as="a"
           key={`${id}-${startsAt}`}
-          onClick={() => stageLoadingCollection(eachCollection)}
+          onClick={() => changeActiveCollection(collection)}
           data-arg={id}
         >
           <b>Session: </b>
@@ -52,7 +54,7 @@ export const MapMenu = ({
       <h2>{mapDate.format("LL")}</h2>
       <p>View a different day:</p>
       <SemanticDatepicker
-        onChange={stageLoadingDate}
+        onChange={changeMapDate}
         format="YYYY-MM-DD"
         value={mapDate.toDate()}
         clearable={false}
@@ -60,11 +62,11 @@ export const MapMenu = ({
       <h3>Collection Details</h3>
       <List>
         <List.Item>
-          <b>Session:</b> {activeCollection.id || "None"}
+          <b>Session:</b> {activeId !== BLANK_ACTIVE_ID ? activeId : "None"}
         </List.Item>
         <b>Start Time:</b>{" "}
-        {activeCollection.starts_at
-          ? moment(activeCollection.starts_at).format("h:mm A")
+        {activeStartsAt
+          ? moment(activeStartsAt).format("h:mm A")
           : "None"}
         {gpsFileUrl ? (
           <List.Item as="a" href={gpsFileUrl}>
@@ -83,13 +85,13 @@ export const MapMenu = ({
       </List>
       <h4>Other Collections from this day:</h4>
       <List>
-        {collectionsDisplay.length ? (
-          collectionsDisplay
+        {otherCollectionsDisplay.length ? (
+          otherCollectionsDisplay
         ) : (
           <List.Item>None</List.Item>
         )}
       </List>
-      {!collectionsOnDate.length && (
+      {activeId === BLANK_ACTIVE_ID && (
         <WarningMessage>
           We haven't collected data for this time period. Please select another
           date.
@@ -102,9 +104,10 @@ export const MapMenu = ({
 MapMenu.propTypes = {
   mapDate: PropTypes.object,
   collectionsOnDate: PropTypes.array,
-  activeCollection: PropTypes.object,
-  stageLoadingDate: PropTypes.func,
-  stageLoadingCollection: PropTypes.func,
+  activeId: PropTypes.number,
+  activeStartsAt: PropTypes.string,
+  changeMapDate: PropTypes.func,
+  changeActiveCollection: PropTypes.func,
   gpsFileUrl: PropTypes.string,
   dustrakFileUrl: PropTypes.string,
 };

--- a/web/src/components/map/menu.js
+++ b/web/src/components/map/menu.js
@@ -65,9 +65,7 @@ export const MapMenu = ({
           <b>Session:</b> {activeId !== BLANK_ACTIVE_ID ? activeId : "None"}
         </List.Item>
         <b>Start Time:</b>{" "}
-        {activeStartsAt
-          ? moment(activeStartsAt).format("h:mm A")
-          : "None"}
+        {activeStartsAt ? moment(activeStartsAt).format("h:mm A") : "None"}
         {gpsFileUrl ? (
           <List.Item as="a" href={gpsFileUrl}>
             Download GPS File

--- a/web/src/components/map/menu.js
+++ b/web/src/components/map/menu.js
@@ -101,7 +101,13 @@ export const MapMenu = ({
 
 MapMenu.propTypes = {
   mapDate: PropTypes.object,
-  collectionsOnDate: PropTypes.array,
+  collectionsOnDate: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string,
+      collection_files: PropTypes.arrayOf(PropTypes.string),
+      starts_at: PropTypes.string,
+    })
+  ),
   activeId: PropTypes.number,
   activeStartsAt: PropTypes.string,
   changeMapDate: PropTypes.func,

--- a/web/src/components/map/menu.js
+++ b/web/src/components/map/menu.js
@@ -67,16 +67,16 @@ export const MapMenu = ({
         </List.Item>
         <b>Start Time:</b>{" "}
         {activeStartsAt ? moment(activeStartsAt).format("h:mm A") : "None"}
-        {gpsFileUrl &&
+        {gpsFileUrl && (
           <List.Item as="a" href={gpsFileUrl}>
             Download GPS File
           </List.Item>
-        }
-        {dustrakFileUrl && 
+        )}
+        {dustrakFileUrl && (
           <List.Item as="a" href={dustrakFileUrl}>
             Download DusTrak File
           </List.Item>
-        }
+        )}
       </List>
       <h4>Other Collections from this day:</h4>
       <List>

--- a/web/src/components/map/menu.js
+++ b/web/src/components/map/menu.js
@@ -10,13 +10,14 @@ import { BLANK_ACTIVE_ID } from "./utils";
 
 /**
  * Menu for Dates and Collections to map
- * @property {moment} mapDate Day viewed on mapped
- * @property {Array<Collection>} collectionsOnDate Collections from the viewed day
- * @property {Collection} activeCollection collection actively viewed on map
- * @property {function} changeMapDate start the process to load collections on date
- * @property {function} changeActiveCollection start the process to load pollutants from a colletion
- * @property {string} gpsFileUrl url to a gps file
- * @property {string} dustrakFileUrl url to a dustrak file
+ * @param {moment} mapDate Day viewed on mapped
+ * @param {Array<import('./utils.js').Collection>} collectionsOnDate Collections from the viewed day
+ * @param {number} activeId id of collection actively viewed on map
+ * @param {string} activeStartsAt start time of the collection as it is stored in the database
+ * @param {function} changeMapDate start the process to load collections on date
+ * @param {function} changeActiveCollection start the process to load pollutants from a colletion
+ * @param {string} gpsFileUrl url to a gps file
+ * @param {string} dustrakFileUrl url to a dustrak file
  */
 export const MapMenu = ({
   mapDate,
@@ -66,20 +67,16 @@ export const MapMenu = ({
         </List.Item>
         <b>Start Time:</b>{" "}
         {activeStartsAt ? moment(activeStartsAt).format("h:mm A") : "None"}
-        {gpsFileUrl ? (
+        {gpsFileUrl &&
           <List.Item as="a" href={gpsFileUrl}>
             Download GPS File
           </List.Item>
-        ) : (
-          <List.Item>No GPS File</List.Item>
-        )}
-        {dustrakFileUrl ? (
+        }
+        {dustrakFileUrl && 
           <List.Item as="a" href={dustrakFileUrl}>
             Download DusTrak File
           </List.Item>
-        ) : (
-          <List.Item>No Dustrak File</List.Item>
-        )}
+        }
       </List>
       <h4>Other Collections from this day:</h4>
       <List>

--- a/web/src/components/map/menu.js
+++ b/web/src/components/map/menu.js
@@ -103,7 +103,7 @@ MapMenu.propTypes = {
   mapDate: PropTypes.object,
   collectionsOnDate: PropTypes.arrayOf(
     PropTypes.shape({
-      id: PropTypes.string,
+      id: PropTypes.number,
       collection_files: PropTypes.arrayOf(PropTypes.string),
       starts_at: PropTypes.string,
     })

--- a/web/src/components/map/menu.test.js
+++ b/web/src/components/map/menu.test.js
@@ -25,8 +25,8 @@ describe("MapMenu", () => {
   it("should render the default map menu, with no collections", () => {
     renderMapMenu({ mapDate });
     expect(screen.getByText(mapDate.format("LL"))).toBeInTheDocument();
-    expect(screen.getByText("No GPS File")).toBeInTheDocument();
-    expect(screen.getByText("No Dustrak File")).toBeInTheDocument();
+    expect(screen.queryByText(/Download GPS File/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Download Dustrak File/)).not.toBeInTheDocument();
     expect(screen.getByText("Session:").closest("div")).toHaveTextContent(
       "None"
     );

--- a/web/src/components/map/menu.test.js
+++ b/web/src/components/map/menu.test.js
@@ -1,0 +1,55 @@
+import {render, screen} from '@testing-library/react'
+import moment from 'moment';
+import { MapMenu } from './menu';
+import { BLANK_ACTIVE_ID } from './utils';
+
+describe("MapMenu", () => {
+    let mapDate;
+    beforeAll(() => {
+        mapDate = moment();
+    });
+
+    it("should render the default map menu, with no collections", () => {
+        renderMapMenu({mapDate});
+        expect(screen.getByText(mapDate.format("LL"))).toBeInTheDocument();
+        expect(screen.getByText("No GPS File")).toBeInTheDocument();
+        expect(screen.getByText("No Dustrak File")).toBeInTheDocument();
+        expect(screen.getByText(/We haven't collected data for this time period./)).toBeInTheDocument();
+    });
+
+    it.skip("should render a single collection", () => {
+
+    });
+
+    it.skip("should render a multiple collections", () => {
+
+    });
+
+    it.skip("should change the active collection", () => {
+
+    });
+
+    it.skip("should change the collection data", () => {
+
+    });
+});
+
+export function getByTextContent(textMatch) {
+    return screen.getByText((content, node) => {
+      const hasText = (node) => node.textContent === textMatch
+      const nodeHasText = hasText(node)
+      const childrenDontHaveText = Array.from(node?.children || []).every((child) => !hasText(child))
+      return nodeHasText && childrenDontHaveText
+    })
+  }
+
+const renderMapMenu = ({
+    mapDate = moment(),
+    collectionsOnDate = [],
+    activeId = BLANK_ACTIVE_ID,
+    activeStartsAt = '',
+    changeMapDate = jest.fn(),
+    changeActiveCollection = jest.fn(),
+    gpsFileUrl = "",
+    dustrakFileUrl = "",
+} = {}) => render(<MapMenu {...{mapDate, collectionsOnDate, activeId, activeStartsAt, changeMapDate, changeActiveCollection, gpsFileUrl, dustrakFileUrl}}/>);

--- a/web/src/components/map/menu.test.js
+++ b/web/src/components/map/menu.test.js
@@ -1,17 +1,25 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import moment from "moment";
 import { MapMenu } from "./menu";
 import { BLANK_ACTIVE_ID } from "./utils";
 
 describe("MapMenu", () => {
   let mapDate;
-  let firstCollection = {
-    id: 0,
-    collection_files: ["gps.io", "dustrak.io"],
-    starts_at: "2014-07-17T19:40:35Z",
-  };
+  let firstCollection;
+  let secondCollection;
   beforeAll(() => {
-    mapDate = moment();
+    mapDate = moment("2014-07-17");
+    firstCollection = {
+      id: 0,
+      collection_files: ["//gps.io", "//dustrak.io"],
+      starts_at: "2014-07-17T19:40:35Z",
+    };
+    secondCollection = {
+      id: 1,
+      collection_files: ["//gps-second.io", "//dustrak-second.io"],
+      starts_at: "2014-07-17T12:40:35Z",
+    };
   });
 
   it("should render the default map menu, with no collections", () => {
@@ -33,34 +41,86 @@ describe("MapMenu", () => {
     );
   });
 
-  it.only("should render a single collection", () => {
+  it("should render a single collection", () => {
+    const collectionsOnDate = [firstCollection];
+    const activeId = firstCollection.id;
+    const activeStartsAt = firstCollection.starts_at;
+    const gpsFileUrl = firstCollection.collection_files[0];
+    const dustrakFileUrl = firstCollection.collection_files[1];
+
     renderMapMenu({
-      mapDate: mapDate,
-      collectionsOnDate: [firstCollection],
-      activeId: firstCollection.id,
-      activeStartsAt: firstCollection.starts_at,
-      gpsFileUrl: firstCollection.collection_files[0],
-      dustrakFileUrl: firstCollection.collection_files[1],
+      mapDate,
+      collectionsOnDate,
+      activeId,
+      activeStartsAt,
+      gpsFileUrl,
+      dustrakFileUrl,
     });
-  });
 
-  it.skip("should render a multiple collections", () => {});
-
-  it.skip("should change the active collection", () => {});
-
-  it.skip("should change the collection data", () => {});
-});
-
-export function getByTextContent(textMatch) {
-  return screen.getByText((content, node) => {
-    const hasText = (node) => node.textContent === textMatch;
-    const nodeHasText = hasText(node);
-    const childrenDontHaveText = Array.from(node?.children || []).every(
-      (child) => !hasText(child)
+    expect(screen.getByText(mapDate.format("LL"))).toBeInTheDocument();
+    expect(screen.getByText("Session:").closest("div")).toHaveTextContent(
+      activeId
     );
-    return nodeHasText && childrenDontHaveText;
+    expect(
+      screen.getByText(moment(activeStartsAt).format("h:mm A"))
+    ).toBeInTheDocument();
+    expect(screen.getByText(/GPS File/).href).toMatch(gpsFileUrl);
+    expect(screen.getByText(/DusTrak File/).href).toMatch(dustrakFileUrl);
+    expect(screen.getByText("None")).toBeInTheDocument();
   });
-}
+
+  it("should render a multiple collections", () => {
+    const collectionsOnDate = [firstCollection, secondCollection];
+    const activeId = secondCollection.id;
+    const activeStartsAt = secondCollection.starts_at;
+    const gpsFileUrl = secondCollection.collection_files[0];
+    const dustrakFileUrl = secondCollection.collection_files[1];
+
+    renderMapMenu({
+      mapDate,
+      collectionsOnDate,
+      activeId,
+      activeStartsAt,
+      gpsFileUrl,
+      dustrakFileUrl,
+    });
+
+    expect(screen.getByText(mapDate.format("LL"))).toBeInTheDocument();
+    const sessions = screen.getAllByText("Session:");
+    expect(sessions[0].closest("div")).toHaveTextContent(activeId);
+    expect(sessions[1].closest("a")).toHaveTextContent(firstCollection.id);
+    expect(
+      screen.getByText(moment(activeStartsAt).format("h:mm A"))
+    ).toBeInTheDocument();
+    expect(screen.getByText(/GPS File/).href).toMatch(gpsFileUrl);
+    expect(screen.getByText(/DusTrak File/).href).toMatch(dustrakFileUrl);
+    expect(screen.queryByText("None")).not.toBeInTheDocument();
+  });
+
+  it("should change the active collection when clicking another one", () => {
+    const collectionsOnDate = [firstCollection, secondCollection];
+    const activeId = firstCollection.id;
+    const changeActiveCollection = jest.fn();
+    renderMapMenu({ activeId, collectionsOnDate, changeActiveCollection });
+    userEvent.click(
+      screen.getByText(
+        new RegExp(moment(secondCollection.starts_at).format("h:mm A"), "i")
+      )
+    );
+    expect(changeActiveCollection).toHaveBeenCalled();
+  });
+
+  it("should change the collection date when clicking the map", () => {
+    const changeMapDate = jest.fn();
+    renderMapMenu({ changeMapDate });
+    userEvent.click(screen.getByTestId("datepicker-input"));
+    // the event is fired when the day changes- not when the datepicker is clicked.
+    expect(changeMapDate).not.toHaveBeenCalled();
+    // the 19th is a day that should always be in the month and not conflict with other text values
+    userEvent.click(screen.getByText("19"));
+    expect(changeMapDate).toHaveBeenCalled();
+  });
+});
 
 const renderMapMenu = ({
   mapDate = moment(),

--- a/web/src/components/map/menu.test.js
+++ b/web/src/components/map/menu.test.js
@@ -9,12 +9,17 @@ describe("MapMenu", () => {
         mapDate = moment();
     });
 
-    it("should render the default map menu, with no collections", () => {
+    it.only("should render the default map menu, with no collections", () => {
         renderMapMenu({mapDate});
         expect(screen.getByText(mapDate.format("LL"))).toBeInTheDocument();
         expect(screen.getByText("No GPS File")).toBeInTheDocument();
         expect(screen.getByText("No Dustrak File")).toBeInTheDocument();
+        expect(screen.getByText("Session:").closest("div")).toHaveTextContent('None');
+        expect(screen.getByText("Start Time:").closest("div")).toHaveTextContent('None');
         expect(screen.getByText(/We haven't collected data for this time period./)).toBeInTheDocument();
+        expect(screen.getByTestId('datepicker-input').value).toMatch(mapDate.format('YYYY-MM-DD'));
+        // console.log(mapDate.format('YYYY-MM-DD'));
+        screen.debug();
     });
 
     it.skip("should render a single collection", () => {

--- a/web/src/components/map/menu.test.js
+++ b/web/src/components/map/menu.test.js
@@ -1,60 +1,88 @@
-import {render, screen} from '@testing-library/react'
-import moment from 'moment';
-import { MapMenu } from './menu';
-import { BLANK_ACTIVE_ID } from './utils';
+import { render, screen } from "@testing-library/react";
+import moment from "moment";
+import { MapMenu } from "./menu";
+import { BLANK_ACTIVE_ID } from "./utils";
 
 describe("MapMenu", () => {
-    let mapDate;
-    beforeAll(() => {
-        mapDate = moment();
+  let mapDate;
+  let firstCollection = {
+    id: 0,
+    collection_files: ["gps.io", "dustrak.io"],
+    starts_at: "2014-07-17T19:40:35Z",
+  };
+  beforeAll(() => {
+    mapDate = moment();
+  });
+
+  it("should render the default map menu, with no collections", () => {
+    renderMapMenu({ mapDate });
+    expect(screen.getByText(mapDate.format("LL"))).toBeInTheDocument();
+    expect(screen.getByText("No GPS File")).toBeInTheDocument();
+    expect(screen.getByText("No Dustrak File")).toBeInTheDocument();
+    expect(screen.getByText("Session:").closest("div")).toHaveTextContent(
+      "None"
+    );
+    expect(screen.getByText("Start Time:").closest("div")).toHaveTextContent(
+      "None"
+    );
+    expect(
+      screen.getByText(/We haven't collected data for this time period./)
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("datepicker-input").value).toMatch(
+      mapDate.format("YYYY-MM-DD")
+    );
+  });
+
+  it.only("should render a single collection", () => {
+    renderMapMenu({
+      mapDate: mapDate,
+      collectionsOnDate: [firstCollection],
+      activeId: firstCollection.id,
+      activeStartsAt: firstCollection.starts_at,
+      gpsFileUrl: firstCollection.collection_files[0],
+      dustrakFileUrl: firstCollection.collection_files[1],
     });
+  });
 
-    it.only("should render the default map menu, with no collections", () => {
-        renderMapMenu({mapDate});
-        expect(screen.getByText(mapDate.format("LL"))).toBeInTheDocument();
-        expect(screen.getByText("No GPS File")).toBeInTheDocument();
-        expect(screen.getByText("No Dustrak File")).toBeInTheDocument();
-        expect(screen.getByText("Session:").closest("div")).toHaveTextContent('None');
-        expect(screen.getByText("Start Time:").closest("div")).toHaveTextContent('None');
-        expect(screen.getByText(/We haven't collected data for this time period./)).toBeInTheDocument();
-        expect(screen.getByTestId('datepicker-input').value).toMatch(mapDate.format('YYYY-MM-DD'));
-        // console.log(mapDate.format('YYYY-MM-DD'));
-        screen.debug();
-    });
+  it.skip("should render a multiple collections", () => {});
 
-    it.skip("should render a single collection", () => {
+  it.skip("should change the active collection", () => {});
 
-    });
-
-    it.skip("should render a multiple collections", () => {
-
-    });
-
-    it.skip("should change the active collection", () => {
-
-    });
-
-    it.skip("should change the collection data", () => {
-
-    });
+  it.skip("should change the collection data", () => {});
 });
 
 export function getByTextContent(textMatch) {
-    return screen.getByText((content, node) => {
-      const hasText = (node) => node.textContent === textMatch
-      const nodeHasText = hasText(node)
-      const childrenDontHaveText = Array.from(node?.children || []).every((child) => !hasText(child))
-      return nodeHasText && childrenDontHaveText
-    })
-  }
+  return screen.getByText((content, node) => {
+    const hasText = (node) => node.textContent === textMatch;
+    const nodeHasText = hasText(node);
+    const childrenDontHaveText = Array.from(node?.children || []).every(
+      (child) => !hasText(child)
+    );
+    return nodeHasText && childrenDontHaveText;
+  });
+}
 
 const renderMapMenu = ({
-    mapDate = moment(),
-    collectionsOnDate = [],
-    activeId = BLANK_ACTIVE_ID,
-    activeStartsAt = '',
-    changeMapDate = jest.fn(),
-    changeActiveCollection = jest.fn(),
-    gpsFileUrl = "",
-    dustrakFileUrl = "",
-} = {}) => render(<MapMenu {...{mapDate, collectionsOnDate, activeId, activeStartsAt, changeMapDate, changeActiveCollection, gpsFileUrl, dustrakFileUrl}}/>);
+  mapDate = moment(),
+  collectionsOnDate = [],
+  activeId = BLANK_ACTIVE_ID,
+  activeStartsAt = "",
+  changeMapDate = jest.fn(),
+  changeActiveCollection = jest.fn(),
+  gpsFileUrl = "",
+  dustrakFileUrl = "",
+} = {}) =>
+  render(
+    <MapMenu
+      {...{
+        mapDate,
+        collectionsOnDate,
+        activeId,
+        activeStartsAt,
+        changeMapDate,
+        changeActiveCollection,
+        gpsFileUrl,
+        dustrakFileUrl,
+      }}
+    />
+  );

--- a/web/src/components/map/utils.js
+++ b/web/src/components/map/utils.js
@@ -168,8 +168,9 @@ const getThrownCode = (thrown) =>
 /**
  * Return the collection that was last added to a date.
  * If no collections were returned for a date, fall back to using an empty object
- * @param {Array<Collection>} pendingCollections possible collections
- * @returns { Collection } Lastest collection or an empty object
+ * @param {Array<Collection>} collections possible collections
+ * @returns { Collection } Latest collection or an empty object
  */
-export const getFirstCollection = (pendingCollections) =>
-  pendingCollections[pendingCollections.length - 1] || BLANK_ACTIVE_COLLECTION;
+export const getFirstCollection = (collections) =>
+  (collections && collections[collections.length - 1]) ||
+  BLANK_ACTIVE_COLLECTION;

--- a/web/src/components/map/utils.js
+++ b/web/src/components/map/utils.js
@@ -22,10 +22,13 @@ import { apiUrlCollectionById, apiUrlCollections } from "../../api.util";
  * @property {number} value
  */
 
-
- export const BLANK_ACTIVE_ID = -1;
- export const BLANK_ACTIVE_STARTS_AT = ""
- export const BLANK_ACTIVE_COLLECTION = { id: BLANK_ACTIVE_ID, collection_files: ["", ""], starts_at: BLANK_ACTIVE_STARTS_AT}
+export const BLANK_ACTIVE_ID = -1;
+export const BLANK_ACTIVE_STARTS_AT = "";
+export const BLANK_ACTIVE_COLLECTION = {
+  id: BLANK_ACTIVE_ID,
+  collection_files: ["", ""],
+  starts_at: BLANK_ACTIVE_STARTS_AT,
+};
 
 /**
  * Retrieve the pollutants that were detected by a given collection session

--- a/web/src/components/map/utils.js
+++ b/web/src/components/map/utils.js
@@ -92,14 +92,14 @@ export const parsePollutants = (pollutantValueData) =>
  * @returns {Pollutant} the shape of the pollutant as the client wants to consume it
  */
 export const parsePollutant = (item) => {
-  const timeGeoSplit = item.time_geo.split("(");
-  const coordsSplit = timeGeoSplit[1].split(", ");
+  const timeGeoSplit = item?.time_geo && item.time_geo.split("(");
+  const coordsSplit = timeGeoSplit && timeGeoSplit[1].split(", ");
   return {
-    timestamp: timeGeoSplit[0].trim(),
-    longitude: Number(coordsSplit[0].trim()),
-    latitude: Number(coordsSplit[1].replace(")", "").trim()),
-    name: item.pollutant,
-    value: item.value,
+    timestamp: timeGeoSplit && timeGeoSplit[0].trim(),
+    longitude: coordsSplit && Number(coordsSplit[0].trim()),
+    latitude: coordsSplit && Number(coordsSplit[1].replace(")", "").trim()),
+    name: item?.pollutant,
+    value: item?.value,
   };
 };
 

--- a/web/src/components/map/utils.js
+++ b/web/src/components/map/utils.js
@@ -22,6 +22,11 @@ import { apiUrlCollectionById, apiUrlCollections } from "../../api.util";
  * @property {number} value
  */
 
+
+ export const BLANK_ACTIVE_ID = -1;
+ export const BLANK_ACTIVE_STARTS_AT = ""
+ export const BLANK_ACTIVE_COLLECTION = { id: BLANK_ACTIVE_ID, collection_files: ["", ""], starts_at: BLANK_ACTIVE_STARTS_AT}
+
 /**
  * Retrieve the pollutants that were detected by a given collection session
  * @param {string} collectionId the integer-like database id of the collection
@@ -106,8 +111,8 @@ export const swapProtocol = (link) => link.replace(/^(https?|ftp):\/\//, "//");
  * @param {Array<Collection>} pendingCollections possible collections
  * @returns {Collection || Object } Lastest collection or an empty object
  */
-export const fallbackCollection = (pendingCollections) =>
-  pendingCollections[pendingCollections.length - 1] || {};
+export const getFirstCollection = (pendingCollections) =>
+  pendingCollections[pendingCollections.length - 1] || BLANK_ACTIVE_COLLECTION;
 
 /**
  * Handle axios throw that may have been a cancel request

--- a/web/src/components/map/utils.js
+++ b/web/src/components/map/utils.js
@@ -142,6 +142,7 @@ export const getCollectionsOnDate = async (
 /**
  * Retrieve data about the collection file, gps or dustrak
  * @param {string} fileLink the url to the file
+ * @param {CancelToken} cancelTokenSource
  * @returns {{ file: CollectionFile || null, thrownCode: THROWN_CODE}} data about the collection file
  */
 export const getCollectionFileByLink = async (fileLink, cancelTokenSource) => {

--- a/web/src/components/map/utils.js
+++ b/web/src/components/map/utils.js
@@ -162,7 +162,7 @@ export const getCollectionFileByLink = async (fileLink, cancelTokenSource) => {
  * @param {Error} thrown error sent to a catch block after
  * @returns {THROWN_CODE} the number associated with a type of failure
  */
-const getThrownCode = (thrown) =>
+export const getThrownCode = (thrown) =>
   axios.isCancel(thrown) ? THROWN_CODE.CANCELED : THROWN_CODE.FAILED;
 
 /**

--- a/web/src/components/map/utils.js
+++ b/web/src/components/map/utils.js
@@ -152,15 +152,6 @@ const getThrownCode = (thrown) =>
   axios.isCancel(thrown) ? THROWN_CODE.CANCELED : THROWN_CODE.FAILED;
 
 /**
- * url is stored in database as http. To prevent mixed content errors (https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content),
- * the production protocol needs to access the link through https.
- * use empty protocol to match application protocol
- * @param {string} link to file download
- * @returns {string} protocol set based on environment
- */
-export const swapProtocol = (link) => link.replace(/^(https?|ftp):\/\//, "//");
-
-/**
  * Return the collection that was last added to a date.
  * If no collections were returned for a date, fall back to using an empty object
  * @param {Array<Collection>} pendingCollections possible collections

--- a/web/src/components/map/utils.js
+++ b/web/src/components/map/utils.js
@@ -41,7 +41,7 @@ export const THROWN_CODE = {
  * @param {string} collectionId the integer-like database id of the collection
  * @param {axios.CancelToken} cancelTokenSource an axios token to cancel the request
  * @returns {{
- * pollutants: Array<PollutantValue>,
+ * pollutants: {pollutant_values: Array<PollutantValue>},
  * thrownCode: number
  * }} pollutants as they are stored in the database. If the response threw, the code for its reason
  */
@@ -59,14 +59,12 @@ export const getPollutantsByCollectionId = async (
     );
     const pollutants = response?.data;
     if (!pollutants) throw new Error("Failed to get pollutants data");
-    if (!Array.isArray(pollutants))
-      throw new Error("Response data for pollutants is not an array");
     return { pollutants: pollutants, thrownCode: THROWN_CODE.NONE };
   } catch (thrown) {
     const thrownCode = axios.isCancel(thrown)
       ? THROWN_CODE.CANCELED
       : THROWN_CODE.FAILED;
-    return { pollutants: [], thrownCode: thrownCode };
+    return { pollutants: {}, thrownCode: thrownCode };
   }
 };
 

--- a/web/src/components/map/utils.js
+++ b/web/src/components/map/utils.js
@@ -22,6 +22,20 @@ import { apiUrlCollectionById, apiUrlCollections } from "../../api.util";
  * @property {number} value
  */
 
+/**
+ * Meta-data for a collection
+ * @typedef Collection
+ * @property {number} id
+ * @property {Array<string>} collection_files
+ * @property {number} starts_at
+ */
+
+/**
+ * Link to the Collection File
+ * @typedef CollectionFile
+ * @property {string} file
+ */
+
 export const BLANK_ACTIVE_ID = -1;
 export const BLANK_ACTIVE_STARTS_AT = "";
 export const BLANK_ACTIVE_COLLECTION = {
@@ -69,7 +83,7 @@ export const getPollutantsByCollectionId = async (
  * Extract and parse the pollutant values, or return an empty array
  * @param {Array<PollutantValue>} pollutantValueData
  */
-export const fallbackPollutants = (pollutantValueData) =>
+export const parsePollutants = (pollutantValueData) =>
   pollutantValueData?.pollutant_values?.map(parsePollutant) || [];
 
 /**
@@ -127,8 +141,8 @@ export const getCollectionsOnDate = async (
 
 /**
  * Retrieve data about the collection file, gps or dustrak
- * @param {string} fileLink the full url to the file
- * @returns {CollectionFile} data about the collection file
+ * @param {string} fileLink the url to the file
+ * @returns {{ file: CollectionFile || null, thrownCode: THROWN_CODE}} data about the collection file
  */
 export const getCollectionFileByLink = async (fileLink, cancelTokenSource) => {
   const options = {
@@ -155,7 +169,7 @@ const getThrownCode = (thrown) =>
  * Return the collection that was last added to a date.
  * If no collections were returned for a date, fall back to using an empty object
  * @param {Array<Collection>} pendingCollections possible collections
- * @returns {Collection || Object } Lastest collection or an empty object
+ * @returns { Collection } Lastest collection or an empty object
  */
 export const getFirstCollection = (pendingCollections) =>
   pendingCollections[pendingCollections.length - 1] || BLANK_ACTIVE_COLLECTION;

--- a/web/src/components/map/utils.js
+++ b/web/src/components/map/utils.js
@@ -85,9 +85,9 @@ export const getCollectionsOnDate = async (mapDate, cancelTokenSource) => {
  * @returns {CollectionFile} data about the collection file
  */
 export const getCollectionFileByLink = async (fileLink, cancelTokenSource) => {
-  const options ={
-    cancelToken: cancelTokenSource.token
-  }
+  const options = {
+    cancelToken: cancelTokenSource.token,
+  };
   return (await axios.get(fileLink, options)).data;
 };
 
@@ -98,12 +98,7 @@ export const getCollectionFileByLink = async (fileLink, cancelTokenSource) => {
  * @param {string} link to file download
  * @returns {string} protocol set based on environment
  */
-export const swapProtocol = (link) => {
-  const protomatch = /^(https?|ftp):\/\//;
-  link.replace(protomatch, "");
-  console.log('link', link);
-  return link;
-}
+export const swapProtocol = (link) => link.replace(/^(https?|ftp):\/\//, "//");
 
 /**
  * Return the collection that was last added to a date.

--- a/web/src/components/map/utils.js
+++ b/web/src/components/map/utils.js
@@ -72,7 +72,7 @@ export const parsePollutant = (item) => {
 export const getCollectionsOnDate = async (mapDate, cancelTokenSource) => {
   const options = {
     params: {
-      start_date: mapDate.format("YYYY-MM-DD"),
+      start_date: mapDate,
     },
     cancelToken: cancelTokenSource.token,
   };

--- a/web/src/components/map/utils.js
+++ b/web/src/components/map/utils.js
@@ -84,19 +84,26 @@ export const getCollectionsOnDate = async (mapDate, cancelTokenSource) => {
  * @param {string} fileLink the full url to the file
  * @returns {CollectionFile} data about the collection file
  */
-export const getCollectionFileByLink = async (fileLink) => {
-  if (!fileLink) return "";
-  return (await axios.get(fileLink)).data;
+export const getCollectionFileByLink = async (fileLink, cancelTokenSource) => {
+  const options ={
+    cancelToken: cancelTokenSource.token
+  }
+  return (await axios.get(fileLink, options)).data;
 };
 
 /**
  * url is stored in database as http. To prevent mixed content errors (https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content),
  * the production protocol needs to access the link through https.
+ * use empty protocol to match application protocol
  * @param {string} link to file download
  * @returns {string} protocol set based on environment
  */
-export const swapProtocol = (link) =>
-  link.replace("http", process.env.REACT_APP_PROTOCOL || "http");
+export const swapProtocol = (link) => {
+  const protomatch = /^(https?|ftp):\/\//;
+  link.replace(protomatch, "");
+  console.log('link', link);
+  return link;
+}
 
 /**
  * Return the collection that was last added to a date.

--- a/web/src/components/map/utils.test.js
+++ b/web/src/components/map/utils.test.js
@@ -83,7 +83,9 @@ describe("get pollutants for a specific collection", () => {
       1,
       axios.CancelToken.source()
     );
-    expect(pollutants.pollutant_values).toEqual([{ time_geo: "Place and time" }]);
+    expect(pollutants.pollutant_values).toEqual([
+      { time_geo: "Place and time" },
+    ]);
     expect(thrownCode).toEqual(THROWN_CODE.NONE);
   });
 
@@ -94,10 +96,10 @@ describe("get pollutants for a specific collection", () => {
       })
     );
 
-    const {
-      pollutants,
-      thrownCode,
-    } = await getPollutantsByCollectionId(0, axios.CancelToken.source());
+    const { pollutants, thrownCode } = await getPollutantsByCollectionId(
+      0,
+      axios.CancelToken.source()
+    );
     expect(pollutants).toEqual({});
     expect(thrownCode).toEqual(THROWN_CODE.FAILED);
   });
@@ -109,10 +111,10 @@ describe("get pollutants for a specific collection", () => {
       })
     );
 
-    const {
-      pollutants,
-      thrownCode,
-    } = await getPollutantsByCollectionId(0, axios.CancelToken.source());
+    const { pollutants, thrownCode } = await getPollutantsByCollectionId(
+      0,
+      axios.CancelToken.source()
+    );
     expect(pollutants).toEqual({});
     expect(thrownCode).toEqual(THROWN_CODE.FAILED);
   });
@@ -124,10 +126,10 @@ describe("get pollutants for a specific collection", () => {
       )
     );
 
-    const {
-      pollutants,
-      thrownCode,
-    } = await getPollutantsByCollectionId(0, axios.CancelToken.source());
+    const { pollutants, thrownCode } = await getPollutantsByCollectionId(
+      0,
+      axios.CancelToken.source()
+    );
     expect(pollutants).toEqual({});
     expect(thrownCode).toEqual(THROWN_CODE.FAILED);
   });
@@ -135,10 +137,10 @@ describe("get pollutants for a specific collection", () => {
   it("should handle canceling a request", async () => {
     const cancelTokenSource = axios.CancelToken.source();
     cancelTokenSource.cancel();
-    const {
-      pollutants,
-      thrownCode,
-    } = await getPollutantsByCollectionId(0, cancelTokenSource);
+    const { pollutants, thrownCode } = await getPollutantsByCollectionId(
+      0,
+      cancelTokenSource
+    );
     expect(pollutants).toEqual({});
     expect(thrownCode).toEqual(THROWN_CODE.CANCELED);
   });
@@ -157,9 +159,12 @@ describe("get files for a specific collection", () => {
         );
       })
     );
-    const { file, errorMessage } = await getCollectionFileByLink(fileLink);
+    const { file, thrownCode } = await getCollectionFileByLink(
+      fileLink,
+      axios.CancelToken.source()
+    );
     expect(file).toEqual(fileFoo);
-    expect(errorMessage).toEqual("");
+    expect(thrownCode).toEqual(THROWN_CODE.NONE);
   });
 
   it("should handle response with corrupt data", async () => {
@@ -170,9 +175,12 @@ describe("get files for a specific collection", () => {
       })
     );
 
-    const { file, errorMessage } = await getCollectionFileByLink(fileLink);
+    const { file, thrownCode } = await getCollectionFileByLink(
+      fileLink,
+      axios.CancelToken.source()
+    );
     expect(file).toBe(null);
-    expect(errorMessage).toMatch("Failed to get file");
+    expect(thrownCode).toEqual(THROWN_CODE.FAILED);
   });
 
   it("should handle server response error", async () => {
@@ -183,16 +191,41 @@ describe("get files for a specific collection", () => {
       })
     );
 
-    const { file, errorMessage } = await getCollectionFileByLink(fileLink);
+    const { file, thrownCode } = await getCollectionFileByLink(
+      fileLink,
+      axios.CancelToken.source()
+    );
     expect(file).toBe(null);
-    expect(errorMessage).toMatch("Error in server response");
+    expect(thrownCode).toEqual(THROWN_CODE.FAILED);
   });
 
   it("should handle network request error", async () => {
     const fileLink = apiUrl("link/to/file");
     server.use(rest.get(fileLink, (req, res, ctx) => res.networkError()));
-    const { file, errorMessage } = await getCollectionFileByLink(fileLink);
+    const { file, thrownCode } = await getCollectionFileByLink(
+      fileLink,
+      axios.CancelToken.source()
+    );
     expect(file).toBe(null);
-    expect(errorMessage).toMatch("Error in network request");
+    expect(thrownCode).toEqual(THROWN_CODE.FAILED);
+  });
+
+  it("should handle canceling a request", async () => {
+    const source = axios.CancelToken.source();
+    source.cancel();
+
+    const fileLink = apiUrl("link/to/file");
+    server.use(
+      rest.get(fileLink, (req, res, ctx) => {
+        return res(ctx.status(200));
+      })
+    );
+
+    const { file, thrownCode } = await getCollectionFileByLink(
+      fileLink,
+      source
+    );
+    expect(file).toBe(null);
+    expect(thrownCode).toEqual(THROWN_CODE.CANCELED);
   });
 });

--- a/web/src/components/map/utils.test.js
+++ b/web/src/components/map/utils.test.js
@@ -1,3 +1,198 @@
-describe("parsePollutant", () => {
-  it.todo("should parse pollutant response");
+import {
+  apiUrl,
+  apiUrlCollectionById,
+  apiUrlCollections,
+} from "../../api.util";
+import {
+  getCollectionFileByLink,
+  getCollectionsOnDate,
+  getPollutantsByCollectionId,
+  THROWN_CODE,
+} from "./utils";
+import axios from "axios";
+import moment from "moment-timezone";
+import { server, rest } from "../../serverHandlers";
+
+describe("get collections from a specific date", () => {
+  it("should successfully receive a list of collections from the data", async () => {
+    const { collectionsOnDate, errorMessage } = await getCollectionsOnDate(
+      moment(),
+      axios.CancelToken.source()
+    );
+    expect(collectionsOnDate).toEqual([1, 2, 3]);
+    expect(errorMessage).toEqual("");
+  });
+
+  it("should handle corrupt data response", async () => {
+    server.use(
+      rest.get(apiUrlCollections(), (_req, res, ctx) => {
+        return res(ctx.status(200));
+      })
+    );
+    const { collectionsOnDate, errorMessage } = await getCollectionsOnDate(
+      moment(),
+      axios.CancelToken.source()
+    );
+    expect(collectionsOnDate).toEqual([]);
+    expect(errorMessage).toMatch("Failed to get collections");
+  });
+
+  it("should handle error responses", async () => {
+    server.use(
+      rest.get(apiUrlCollections(), (_req, res, ctx) => {
+        return res(ctx.status(503));
+      })
+    );
+
+    const { collectionsOnDate, errorMessage } = await getCollectionsOnDate(
+      moment(),
+      axios.CancelToken.source()
+    );
+    expect(collectionsOnDate).toEqual([]);
+    expect(errorMessage).toMatch("Error in server response");
+  });
+
+  it("should handle network error", async () => {
+    server.use(
+      rest.get(apiUrlCollections(), (_req, res, _ctx) => res.networkError())
+    );
+
+    const { collectionsOnDate, errorMessage } = await getCollectionsOnDate(
+      moment(),
+      axios.CancelToken.source()
+    );
+    expect(collectionsOnDate).toEqual([]);
+    expect(errorMessage).toMatch("Error in network request");
+  });
+
+  it("should handle canceling a request", async () => {
+    const cancelTokenSource = axios.CancelToken.source();
+    cancelTokenSource.cancel();
+    const { collectionsOnDate, errorMessage } = await getCollectionsOnDate(
+      moment(),
+      cancelTokenSource
+    );
+    expect(collectionsOnDate).toEqual([]);
+    expect(errorMessage).toMatch("Canceled");
+  });
+});
+
+describe.only("get pollutants for a specific collection", () => {
+  it.only("should successfully receive pollutants", async () => {
+    const { pollutants, thrownCode } = await getPollutantsByCollectionId(
+      1,
+      axios.CancelToken.source()
+    );
+    expect(pollutants).toEqual([{ time_geo: "Place and time" }]);
+    expect(thrownCode).toEqual(THROWN_CODE.NONE);
+  });
+
+  it("should handle response with corrupt data", async () => {
+    server.use(
+      rest.get(apiUrlCollectionById("*"), (_req, res, ctx) => {
+        return res(ctx.status(200));
+      })
+    );
+
+    const {
+      pollutantsInCollection,
+      errorMessage,
+    } = await getPollutantsByCollectionId(0, axios.CancelToken.source());
+    expect(pollutantsInCollection).toEqual([]);
+    expect(errorMessage).toMatch("Failed to get");
+  });
+
+  it("should handle server response error", async () => {
+    server.use(
+      rest.get(apiUrlCollectionById("*"), (_req, res, ctx) => {
+        return res(ctx.status(503));
+      })
+    );
+
+    const {
+      pollutantsInCollection,
+      errorMessage,
+    } = await getPollutantsByCollectionId(0, axios.CancelToken.source());
+    expect(pollutantsInCollection).toEqual([]);
+    expect(errorMessage).toMatch("Error in server response");
+  });
+
+  it("should handle network request error", async () => {
+    server.use(
+      rest.get(apiUrlCollectionById("*"), (_req, res, _ctx) =>
+        res.networkError()
+      )
+    );
+
+    const {
+      pollutantsInCollection,
+      errorMessage,
+    } = await getPollutantsByCollectionId(0, axios.CancelToken.source());
+    expect(pollutantsInCollection).toEqual([]);
+    expect(errorMessage).toMatch("Error in network request");
+  });
+
+  it("should handle canceling a request", async () => {
+    const cancelTokenSource = axios.CancelToken.source();
+    cancelTokenSource.cancel();
+    const {
+      pollutantsInCollection,
+      errorMessage,
+    } = await getPollutantsByCollectionId(0, cancelTokenSource);
+    expect(pollutantsInCollection).toEqual([]);
+    expect(errorMessage).toMatch("Canceled");
+  });
+});
+
+describe("get files for a specific collection", () => {
+  it("should successfully receive files", async () => {
+    const fileLink = apiUrl("/link/to/file");
+    const fileFoo = new File(["foo"], "foo.csv", { type: "text/csv" });
+    server.use(
+      rest.get(fileLink, (req, res, ctx) => {
+        return res(
+          ctx.status(200),
+          ctx.set("Content-Type", "text/csv"),
+          ctx.body(fileFoo)
+        );
+      })
+    );
+    const { file, errorMessage } = await getCollectionFileByLink(fileLink);
+    expect(file).toEqual(fileFoo);
+    expect(errorMessage).toEqual("");
+  });
+
+  it("should handle response with corrupt data", async () => {
+    const fileLink = apiUrl("link/to/file");
+    server.use(
+      rest.get(fileLink, (req, res, ctx) => {
+        return res(ctx.status(200));
+      })
+    );
+
+    const { file, errorMessage } = await getCollectionFileByLink(fileLink);
+    expect(file).toBe(null);
+    expect(errorMessage).toMatch("Failed to get file");
+  });
+
+  it("should handle server response error", async () => {
+    const fileLink = apiUrl("link/to/file");
+    server.use(
+      rest.get(fileLink, (req, res, ctx) => {
+        return res(ctx.status(503));
+      })
+    );
+
+    const { file, errorMessage } = await getCollectionFileByLink(fileLink);
+    expect(file).toBe(null);
+    expect(errorMessage).toMatch("Error in server response");
+  });
+
+  it("should handle network request error", async () => {
+    const fileLink = apiUrl("link/to/file");
+    server.use(rest.get(fileLink, (req, res, ctx) => res.networkError()));
+    const { file, errorMessage } = await getCollectionFileByLink(fileLink);
+    expect(file).toBe(null);
+    expect(errorMessage).toMatch("Error in network request");
+  });
 });

--- a/web/src/components/map/utils.test.js
+++ b/web/src/components/map/utils.test.js
@@ -4,8 +4,10 @@ import {
   apiUrlCollections,
 } from "../../api.util";
 import {
+  BLANK_ACTIVE_COLLECTION,
   getCollectionFileByLink,
   getCollectionsOnDate,
+  getFirstCollection,
   getPollutantsByCollectionId,
   parsePollutant,
   parsePollutants,
@@ -319,11 +321,55 @@ describe("get the code associated with a thrown value on api call", () => {
 });
 
 describe("get first collection from a list of collections", () => {
-  it.todo("should get the only collection in a list of one");
+  it("should get the only collection in a list of one", () => {
+    const inputCollections = [
+      {
+        id: 1,
+        starts_at: "2014-07-17T19:40:35Z",
+        ends_at: "2014-07-17T20:33:35Z",
+        collection_files: [
+          "http://api.lvh.me/collection_files/2",
+          "http://api.lvh.me/collection_files/1",
+        ],
+      },
+    ];
+    expect(getFirstCollection(inputCollections)).toStrictEqual(
+      inputCollections[0]
+    );
+  });
 
-  it.todo("should get the first collection in a list of two");
+  it("should get the first collection in a list of two", () => {
+    const inputCollections = [
+      {
+        id: 1,
+        starts_at: "2014-07-17T19:40:35Z",
+        ends_at: "2014-07-17T20:33:35Z",
+        collection_files: [
+          "http://api.lvh.me/collection_files/2",
+          "http://api.lvh.me/collection_files/1",
+        ],
+      },
+      {
+        id: 8,
+        starts_at: "2014-07-17T19:40:35Z",
+        ends_at: "2014-07-17T20:33:35Z",
+        collection_files: [
+          "http://api.lvh.me/collection_files/12",
+          "http://api.lvh.me/collection_files/11",
+        ],
+      },
+    ];
 
-  it.todo("should return the blank collection in an empty list");
+    expect(getFirstCollection(inputCollections)).toStrictEqual(
+      inputCollections[1]
+    );
+  });
 
-  it.todo("should return the blank collection in an undefined list");
+  it("should return the blank collection in an empty list", () =>
+    expect(getFirstCollection([])).toStrictEqual(BLANK_ACTIVE_COLLECTION));
+
+  it("should return the blank collection in an undefined list", () =>
+    expect(getFirstCollection(undefined)).toStrictEqual(
+      BLANK_ACTIVE_COLLECTION
+    ));
 });

--- a/web/src/components/map/utils.test.js
+++ b/web/src/components/map/utils.test.js
@@ -146,6 +146,18 @@ describe("get pollutants for a specific collection", () => {
   });
 });
 
+describe("parse a list of pollutants", () => {
+  it.todo("should return a list of two properly parsed pollutants");
+
+  it.todo("should return an empty list when source data are undefined");
+});
+
+describe("parse each pollutant", () => {
+  it.todo("should return a properly parsed pollutant");
+
+  it.todo("should return a malformed pollutant");
+});
+
 describe("get files for a specific collection", () => {
   it("should successfully receive files", async () => {
     const fileLink = apiUrl("/link/to/file");
@@ -228,4 +240,20 @@ describe("get files for a specific collection", () => {
     expect(file).toBe(null);
     expect(thrownCode).toEqual(THROWN_CODE.CANCELED);
   });
+});
+
+describe("get the code associated with a thrown value on api call", () => {
+  it.todo("should return a 'canceled' code when caused by canceling");
+
+  it.todo("should return a 'failed' code when unrelated to canceling");
+});
+
+describe("get first collection from a list of collections", () => {
+  it.todo("should get the only collection in a list of one");
+
+  it.todo("should get the first collection in a list of two");
+
+  it.todo("should return the blank collection in an empty list");
+
+  it.todo("should return the blank collection in an undefined list");
 });

--- a/web/src/components/map/utils.test.js
+++ b/web/src/components/map/utils.test.js
@@ -77,13 +77,13 @@ describe("get collections from a specific date", () => {
   });
 });
 
-describe.only("get pollutants for a specific collection", () => {
+describe("get pollutants for a specific collection", () => {
   it("should successfully receive pollutants", async () => {
     const { pollutants, thrownCode } = await getPollutantsByCollectionId(
       1,
       axios.CancelToken.source()
     );
-    expect(pollutants).toEqual([{ time_geo: "Place and time" }]);
+    expect(pollutants.pollutant_values).toEqual([{ time_geo: "Place and time" }]);
     expect(thrownCode).toEqual(THROWN_CODE.NONE);
   });
 
@@ -98,7 +98,7 @@ describe.only("get pollutants for a specific collection", () => {
       pollutants,
       thrownCode,
     } = await getPollutantsByCollectionId(0, axios.CancelToken.source());
-    expect(pollutants).toEqual([]);
+    expect(pollutants).toEqual({});
     expect(thrownCode).toEqual(THROWN_CODE.FAILED);
   });
 
@@ -113,7 +113,7 @@ describe.only("get pollutants for a specific collection", () => {
       pollutants,
       thrownCode,
     } = await getPollutantsByCollectionId(0, axios.CancelToken.source());
-    expect(pollutants).toEqual([]);
+    expect(pollutants).toEqual({});
     expect(thrownCode).toEqual(THROWN_CODE.FAILED);
   });
 
@@ -128,7 +128,7 @@ describe.only("get pollutants for a specific collection", () => {
       pollutants,
       thrownCode,
     } = await getPollutantsByCollectionId(0, axios.CancelToken.source());
-    expect(pollutants).toEqual([]);
+    expect(pollutants).toEqual({});
     expect(thrownCode).toEqual(THROWN_CODE.FAILED);
   });
 
@@ -139,7 +139,7 @@ describe.only("get pollutants for a specific collection", () => {
       pollutants,
       thrownCode,
     } = await getPollutantsByCollectionId(0, cancelTokenSource);
-    expect(pollutants).toEqual([]);
+    expect(pollutants).toEqual({});
     expect(thrownCode).toEqual(THROWN_CODE.CANCELED);
   });
 });

--- a/web/src/components/map/utils.test.js
+++ b/web/src/components/map/utils.test.js
@@ -320,10 +320,12 @@ describe("get the code associated with a thrown value on api call", () => {
     let thrownCode;
     const source = axios.CancelToken.source();
     source.cancel();
-    server.use(rest.get('/'), (req, res, ctx) => { return res(ctx.status(200))});
+    server.use(rest.get("/"), (req, res, ctx) => {
+      return res(ctx.status(200));
+    });
     try {
-      await axios.get('/', {cancelToken: source.token})
-    } catch(thrown) {
+      await axios.get("/", { cancelToken: source.token });
+    } catch (thrown) {
       thrownCode = getThrownCode(thrown);
     }
     expect(thrownCode).toEqual(THROWN_CODE.CANCELED);
@@ -331,9 +333,9 @@ describe("get the code associated with a thrown value on api call", () => {
 
   it("should return a 'failed' code when unrelated to canceling", () => {
     let thrownCode;
-    try{
+    try {
       throw new Error("failed");
-    } catch(thrown){
+    } catch (thrown) {
       thrownCode = getThrownCode(thrown);
     }
     expect(thrownCode).toEqual(THROWN_CODE.FAILED);

--- a/web/src/components/map/utils.test.js
+++ b/web/src/components/map/utils.test.js
@@ -9,6 +9,7 @@ import {
   getCollectionsOnDate,
   getFirstCollection,
   getPollutantsByCollectionId,
+  getThrownCode,
   parsePollutant,
   parsePollutants,
   THROWN_CODE,
@@ -315,9 +316,28 @@ describe("get files for a specific collection", () => {
 });
 
 describe("get the code associated with a thrown value on api call", () => {
-  it.todo("should return a 'canceled' code when caused by canceling");
+  it("should return a 'canceled' code when caused by canceling", async () => {
+    let thrownCode;
+    const source = axios.CancelToken.source();
+    source.cancel();
+    server.use(rest.get('/'), (req, res, ctx) => { return res(ctx.status(200))});
+    try {
+      await axios.get('/', {cancelToken: source.token})
+    } catch(thrown) {
+      thrownCode = getThrownCode(thrown);
+    }
+    expect(thrownCode).toEqual(THROWN_CODE.CANCELED);
+  });
 
-  it.todo("should return a 'failed' code when unrelated to canceling");
+  it("should return a 'failed' code when unrelated to canceling", () => {
+    let thrownCode;
+    try{
+      throw new Error("failed");
+    } catch(thrown){
+      thrownCode = getThrownCode(thrown);
+    }
+    expect(thrownCode).toEqual(THROWN_CODE.FAILED);
+  });
 });
 
 describe("get first collection from a list of collections", () => {

--- a/web/src/components/map/utils.test.js
+++ b/web/src/components/map/utils.test.js
@@ -15,26 +15,26 @@ import { server, rest } from "../../serverHandlers";
 
 describe("get collections from a specific date", () => {
   it("should successfully receive a list of collections from the data", async () => {
-    const { collectionsOnDate, errorMessage } = await getCollectionsOnDate(
+    const { collectionsOnDate, thrownCode } = await getCollectionsOnDate(
       moment(),
       axios.CancelToken.source()
     );
     expect(collectionsOnDate).toEqual([1, 2, 3]);
-    expect(errorMessage).toEqual("");
+    expect(thrownCode).toEqual(THROWN_CODE.NONE);
   });
 
   it("should handle corrupt data response", async () => {
     server.use(
       rest.get(apiUrlCollections(), (_req, res, ctx) => {
-        return res(ctx.status(200));
+        return res(ctx.status(200), ctx.json({}));
       })
     );
-    const { collectionsOnDate, errorMessage } = await getCollectionsOnDate(
+    const { collectionsOnDate, thrownCode } = await getCollectionsOnDate(
       moment(),
       axios.CancelToken.source()
     );
     expect(collectionsOnDate).toEqual([]);
-    expect(errorMessage).toMatch("Failed to get collections");
+    expect(thrownCode).toEqual(THROWN_CODE.FAILED);
   });
 
   it("should handle error responses", async () => {
@@ -44,12 +44,12 @@ describe("get collections from a specific date", () => {
       })
     );
 
-    const { collectionsOnDate, errorMessage } = await getCollectionsOnDate(
+    const { collectionsOnDate, thrownCode } = await getCollectionsOnDate(
       moment(),
       axios.CancelToken.source()
     );
     expect(collectionsOnDate).toEqual([]);
-    expect(errorMessage).toMatch("Error in server response");
+    expect(thrownCode).toEqual(THROWN_CODE.FAILED);
   });
 
   it("should handle network error", async () => {
@@ -57,23 +57,23 @@ describe("get collections from a specific date", () => {
       rest.get(apiUrlCollections(), (_req, res, _ctx) => res.networkError())
     );
 
-    const { collectionsOnDate, errorMessage } = await getCollectionsOnDate(
+    const { collectionsOnDate, thrownCode } = await getCollectionsOnDate(
       moment(),
       axios.CancelToken.source()
     );
     expect(collectionsOnDate).toEqual([]);
-    expect(errorMessage).toMatch("Error in network request");
+    expect(thrownCode).toEqual(THROWN_CODE.FAILED);
   });
 
   it("should handle canceling a request", async () => {
     const cancelTokenSource = axios.CancelToken.source();
     cancelTokenSource.cancel();
-    const { collectionsOnDate, errorMessage } = await getCollectionsOnDate(
+    const { collectionsOnDate, thrownCode } = await getCollectionsOnDate(
       moment(),
       cancelTokenSource
     );
     expect(collectionsOnDate).toEqual([]);
-    expect(errorMessage).toMatch("Canceled");
+    expect(thrownCode).toEqual(THROWN_CODE.CANCELED);
   });
 });
 

--- a/web/src/components/map/utils.test.js
+++ b/web/src/components/map/utils.test.js
@@ -78,7 +78,7 @@ describe("get collections from a specific date", () => {
 });
 
 describe.only("get pollutants for a specific collection", () => {
-  it.only("should successfully receive pollutants", async () => {
+  it("should successfully receive pollutants", async () => {
     const { pollutants, thrownCode } = await getPollutantsByCollectionId(
       1,
       axios.CancelToken.source()
@@ -95,11 +95,11 @@ describe.only("get pollutants for a specific collection", () => {
     );
 
     const {
-      pollutantsInCollection,
-      errorMessage,
+      pollutants,
+      thrownCode,
     } = await getPollutantsByCollectionId(0, axios.CancelToken.source());
-    expect(pollutantsInCollection).toEqual([]);
-    expect(errorMessage).toMatch("Failed to get");
+    expect(pollutants).toEqual([]);
+    expect(thrownCode).toEqual(THROWN_CODE.FAILED);
   });
 
   it("should handle server response error", async () => {
@@ -110,11 +110,11 @@ describe.only("get pollutants for a specific collection", () => {
     );
 
     const {
-      pollutantsInCollection,
-      errorMessage,
+      pollutants,
+      thrownCode,
     } = await getPollutantsByCollectionId(0, axios.CancelToken.source());
-    expect(pollutantsInCollection).toEqual([]);
-    expect(errorMessage).toMatch("Error in server response");
+    expect(pollutants).toEqual([]);
+    expect(thrownCode).toEqual(THROWN_CODE.FAILED);
   });
 
   it("should handle network request error", async () => {
@@ -125,22 +125,22 @@ describe.only("get pollutants for a specific collection", () => {
     );
 
     const {
-      pollutantsInCollection,
-      errorMessage,
+      pollutants,
+      thrownCode,
     } = await getPollutantsByCollectionId(0, axios.CancelToken.source());
-    expect(pollutantsInCollection).toEqual([]);
-    expect(errorMessage).toMatch("Error in network request");
+    expect(pollutants).toEqual([]);
+    expect(thrownCode).toEqual(THROWN_CODE.FAILED);
   });
 
   it("should handle canceling a request", async () => {
     const cancelTokenSource = axios.CancelToken.source();
     cancelTokenSource.cancel();
     const {
-      pollutantsInCollection,
-      errorMessage,
+      pollutants,
+      thrownCode,
     } = await getPollutantsByCollectionId(0, cancelTokenSource);
-    expect(pollutantsInCollection).toEqual([]);
-    expect(errorMessage).toMatch("Canceled");
+    expect(pollutants).toEqual([]);
+    expect(thrownCode).toEqual(THROWN_CODE.CANCELED);
   });
 });
 

--- a/web/src/components/map/utils.test.js
+++ b/web/src/components/map/utils.test.js
@@ -7,6 +7,8 @@ import {
   getCollectionFileByLink,
   getCollectionsOnDate,
   getPollutantsByCollectionId,
+  parsePollutant,
+  parsePollutants,
   THROWN_CODE,
 } from "./utils";
 import axios from "axios";
@@ -147,15 +149,83 @@ describe("get pollutants for a specific collection", () => {
 });
 
 describe("parse a list of pollutants", () => {
-  it.todo("should return a list of two properly parsed pollutants");
+  it("should return a list of two properly parsed pollutants", () => {
+    const firstInputPollutant = {
+      pollutant: "particulates",
+      time_geo: "2014-07-17 19:40:36 (-122.29460333333333, 37.803158333333336)",
+      value: 0.008,
+    };
 
-  it.todo("should return an empty list when source data are undefined");
+    const firstOutputPollutant = {
+      timestamp: "2014-07-17 19:40:36",
+      longitude: -122.29460333333333,
+      latitude: 37.803158333333336,
+      name: "particulates",
+      value: 0.008,
+    };
+
+    const secondInputPollutant = {
+      pollutant: "particulates",
+      time_geo: "2014-07-17 19:40:37 (-122.29460333333555, 37.744458333333336)",
+      value: 0.009,
+    };
+
+    const secondOutputPollutant = {
+      timestamp: "2014-07-17 19:40:37",
+      longitude: -122.29460333333555,
+      latitude: 37.744458333333336,
+      name: "particulates",
+      value: 0.009,
+    };
+
+    const inputPollutantValues = {
+      pollutant_values: [firstInputPollutant, secondInputPollutant],
+    };
+    const outputPollutantValues = parsePollutants(inputPollutantValues);
+    expect(outputPollutantValues[0]).toStrictEqual(firstOutputPollutant);
+    expect(outputPollutantValues[1]).toStrictEqual(secondOutputPollutant);
+  });
+
+  it("should return an empty list when source data are undefined", () =>
+    expect(parsePollutants(undefined)).toEqual([]));
 });
 
 describe("parse each pollutant", () => {
-  it.todo("should return a properly parsed pollutant");
+  it("should return a properly parsed pollutant", () => {
+    const inputPollutant = {
+      pollutant: "particulates",
+      time_geo: "2014-07-17 19:40:36 (-122.29460333333333, 37.803158333333336)",
+      value: 0.008,
+    };
 
-  it.todo("should return a malformed pollutant");
+    const outputPollutant = {
+      timestamp: "2014-07-17 19:40:36",
+      longitude: -122.29460333333333,
+      latitude: 37.803158333333336,
+      name: "particulates",
+      value: 0.008,
+    };
+
+    expect(parsePollutant(inputPollutant)).toStrictEqual(outputPollutant);
+  });
+
+  it("should return from a malformed pollutant", () =>
+    expect(parsePollutant({})).toStrictEqual({
+      timestamp: undefined,
+      longitude: undefined,
+      latitude: undefined,
+      name: undefined,
+      value: undefined,
+    }));
+
+  it("should return from an undefined pollutant", () =>
+    expect(parsePollutant(undefined)).toStrictEqual({
+      timestamp: undefined,
+      longitude: undefined,
+      latitude: undefined,
+      name: undefined,
+      value: undefined,
+    }));
 });
 
 describe("get files for a specific collection", () => {

--- a/web/src/serverHandlers.js
+++ b/web/src/serverHandlers.js
@@ -8,7 +8,10 @@ const handlers = [
   }),
 
   rest.get(apiUrlCollectionById("*"), (_req, res, ctx) => {
-    return res(ctx.status(200), ctx.json({pollutant_values: [{ time_geo: "Place and time" }]}));
+    return res(
+      ctx.status(200),
+      ctx.json({ pollutant_values: [{ time_geo: "Place and time" }] })
+    );
   }),
 ];
 

--- a/web/src/serverHandlers.js
+++ b/web/src/serverHandlers.js
@@ -1,0 +1,17 @@
+import { rest } from "msw";
+import { setupServer } from "msw/node";
+import { apiUrlCollections, apiUrlCollectionById } from "../src/api.util";
+
+const handlers = [
+  rest.get(apiUrlCollections(), async (_req, res, ctx) => {
+    return res(ctx.status(200), ctx.json([1, 2, 3]));
+  }),
+
+  rest.get(apiUrlCollectionById("*"), (_req, res, ctx) => {
+    return res(ctx.status(200), ctx.json([{ time_geo: "Place and time" }]));
+  }),
+];
+
+const server = setupServer(...handlers);
+
+export { server, rest, handlers };

--- a/web/src/serverHandlers.js
+++ b/web/src/serverHandlers.js
@@ -8,7 +8,7 @@ const handlers = [
   }),
 
   rest.get(apiUrlCollectionById("*"), (_req, res, ctx) => {
-    return res(ctx.status(200), ctx.json([{ time_geo: "Place and time" }]));
+    return res(ctx.status(200), ctx.json({pollutant_values: [{ time_geo: "Place and time" }]}));
   }),
 ];
 

--- a/web/src/setupTests.js
+++ b/web/src/setupTests.js
@@ -3,3 +3,8 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import "@testing-library/jest-dom";
+import { server } from "./serverHandlers";
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());


### PR DESCRIPTION
## Checklist
- [x] Add description
- [x] Reference the open issue that the pull request addresses
- [x] Pass code quality checks
  - spin up docker `docker-compose up -d --build`
  - enter api container `docker-compose exec api /bin/bash`
  - run api tests `make validate`
  - exit container `ctrl/command+D` or `exit`
  - enter web container `docker-compose exec web /bin/sh`
  - run front-end tests `npm run test` or `npx jest`
  - lint `npm run lint-fix`
  - exit container as above
- [x] Request code review
  - Please allow **36 hours** from opening a pull request before merging a pull request- even if it has already received an approving review.
- [ ] Address comments on code and resolve requested changes
- [ ] Merge own code

## Description
Issue: #361

Refactor the api requests for pollutant data and metadata to be simpler and more robust to errors.

Changes by file:
- `package.json`
  - linting rules specifically for react hooks, to catch errors
  - mock service worker (msw)- mocks network requests for tests
 - `web/src/api.util.js`
   - Move the utility function used to modify the protocol to the api utility, as it primarily helps with api calls
   - Simplify it to use empty protocol, instead of relying on env variables.
- `web/src/components/map/index.js`
  - cancel tokens are defined and used completely within their 'effects'. They are automatically canceled when the effect reruns to make another call.
  - try-catch blocks are moved to the utility function making the api call, making unit testing of various errors easier
  - api calls return an "Thrown code" to indicate whether it was a successfully, failed, or canceled call. This is a simple system but can be scaled later to give more detailed error feedback.
  - The 'effects' of each call now only affect data directly related to their api calls
  - The dependency arrays now only contain primitive types. React has trouble determining whether objects have changed, 
  - `isLoadingPollutants` has more robust logic to provide more accurate feedback. It will only start just before a call. If the call was canceled, then it will not reset the loading status, as canceled calls only happen when another call has begun. 
  - api requests have generally more robust guards, only making calls when the source data are valid
  - renamed and refactored the helper functions that reset the collection or date
- web/src/components/map/menu.js
  - update the props and proptypes to reflect the updated data and provide a more detailed definition of the props
  - Refactor guards based on premise that data are always defined and the data has significance
  -  Remove the `No [file type] file` messaging; there may be files but they are still loading.
  - specify in variable name that `collectionsDisplay` is for collections "other" than active.
  - Only display warning message when there is no active collection it- checking a primitive, rather than doing a lookup on an object property
- `web/src/components/map/menu.test.js`
  - test the display of data when it takes various forms
- `web/src/components/map/utils.js`
  - Constants for blank collections to indicate a specific state that other parts of the component may check for
  - Constants for types of api responses that other parts of the component may check for
  - Update api requests to hold their own try-catch, returning a "thrownCode" along with defined data. This discards data specific to the error. But, we can always iterate on the design to actually use this data.
  - Update pollutant parser to guard against undefined data
  - No longer need to swap protocol based on env as we use the empty protocol
  - No longer use the canceled request messages
  - Rename some functions to provide a more accurate description
- `web/src/components/map/utils.test.js`
  - unit tests for functions
  - test network/api requests using msw
-  `web/src/serverHandlers.js`
  - setup of server
  - definition of successful request
- `web/src/setupTests.js`
  - automatically run the mock server for all tests 
