### PR TITLE
Api compose

### DIFF
--- a/.github/deployment.md
+++ b/.github/deployment.md
@@ -11,15 +11,16 @@ A configuration suitable for development
 Steps:
 1. docker-compose up --build
 
-## Livewire
-A basic configuration to allow user to interact with a live site
+## Api Docker Build
+A basic configuration to allow user to interact with a live site.
+API is hosted on Digital Ocean. Front end is hosted on Netlify.
 - All data served on an Amazon EC2 machine
 - Files saved using Django's file manager
 - React uses production build
 - Routes traffic from outside the machine
 
 Steps
-1. docker-compose -f docker-compose.yml -f docker-compose.livewire.yml up --build
+1. docker-compose -f docker-compose.yml -f docker-compose.api.yml up --build
 
 ## WIP: Development
 A basic configuration to allow experimental changes to be hosted and testing remotely.

--- a/docker-compose.api.yml
+++ b/docker-compose.api.yml
@@ -1,0 +1,77 @@
+# Live environment with all services cenralized to one machine
+
+version: '3.3'
+
+services:
+  api:
+    build:
+      args:
+        - PYTHON_ENV=prod
+    ports:
+      - ${API_PORT}
+    environment:
+      SECRET_KEY: ${SECRET_KEY}
+      DATABASE_URL: postgis://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/woaq
+      DEFAULT_FILE_STORAGE: django.core.files.storage.FileSystemStorage
+      LETSENCRYPT_HOST: ${API_DOMAIN}
+      VIRTUAL_HOST: ${API_DOMAIN}
+      VIRTUAL_PORT: ${API_PORT}
+    volumes:
+      - ./api:/usr/src/app
+      - logs:/usr/src/app/logs
+      - static:/usr/src/app/public/static
+    depends_on:
+      - db
+    restart: always
+    stdin_open: true
+    tty: true
+  db:
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: woaq
+    volumes:
+      - postgres:/var/lib/postgresql/data
+    ports:
+      - 5432
+    restart: always
+
+  proxy:
+    build:
+      args:
+        - API_DOMAIN=${API_DOMAIN}
+    ports:
+      - 80:80
+      - 443:443
+    volumes:
+      - 'html:/usr/share/nginx/html'
+      - "dhparam:/etc/nginx/dhparam"
+      - 'vhost:/etc/nginx/vhost.d'
+      - 'certs:/etc/nginx/certs'
+      - '/var/run/docker.sock:/tmp/docker.sock:ro'
+      - static:/var/www/html/static/
+
+  ssl:
+    image: jrcs/letsencrypt-nginx-proxy-companion
+    volumes:
+      - 'html:/usr/share/nginx/html'
+      - "dhparam:/etc/nginx/dhparam"
+      - 'vhost:/etc/nginx/vhost.d'
+      - 'certs:/etc/nginx/certs'
+      - "/run/docker.sock:/var/run/docker.sock:ro"
+    environment:
+      NGINX_PROXY_CONTAINER: "woaq-proxy"
+      DEFAULT_EMAIL: ${DEFAULT_EMAIL}
+    restart: always
+    depends_on: 
+      - "proxy"
+
+          
+volumes:
+  logs:
+  postgres:
+  static:
+  certs:
+  html:
+  vhost:
+  dhparam:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,4 @@
+version: '3.3'
 
 services:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.3'
 
 services:
 
@@ -7,12 +6,6 @@ services:
       context: api
     container_name: woaq-api
     image: openoakland/woaq-api
-
-  web:
-    build:
-      context: web
-    container_name: woaq-web
-    image: openoakland/woaq-web
 
   db:
     container_name: woaq-db


### PR DESCRIPTION
## Description
This is a step toward removing docker from deployment process. As Netlify hosts the front end, we can remove the `web` application from the docker-compose build process. We do this by 1) Removing it from the 'docker-compose` file and 2) Creating a `docker-compose.api` that excludes it from the build process. Now, only the api server, api, and database are hosted on Digital Ocean.
