### PR TITLE
443 production datepicker styles

### DIFF
--- a/web/src/components/map/menu.css
+++ b/web/src/components/map/menu.css
@@ -10,7 +10,7 @@
 button.clndr-cell {
   background-color: lightblue;
   border-radius: 50%;
-  opacity: 100%;
+  opacity: 1;
 }
 
 button.clndr-cell:hover {

--- a/web/src/components/map/menu.css
+++ b/web/src/components/map/menu.css
@@ -30,7 +30,11 @@ button.clndr-cell-selected {
   color: white;
 }
 
-.clndr-days {
+/* the `div` selector is needed for the production build, in
+ * which certain semantic-ui-react-datepicker styles are duplicated
+ * in a <style> tag that overrides this css.
+ */
+div.clndr-days {
   background-color: rgba(255, 255, 255, 1);
   border: 1px solid white; /* hack to get rid of border */
 }


### PR DESCRIPTION
## Checklist
- [x] Add description
- [x] Reference the open issue that the pull request addresses
- [x] Pass code quality checks
  - spin up docker `docker-compose up -d --build`
  - enter api container `docker-compose exec api /bin/bash`
  - run api tests `make validate`
  - exit container `ctrl/command+D` or `exit`
  - enter web container `docker-compose exec web /bin/sh`
  - run front-end tests `npm run test` or `npx jest`
  - lint `npm run lint-fix`
  - exit container as above
- [x] Request code review
  - Please allow **36 hours** from opening a pull request before merging a pull request- even if it has already received an approving review.
- [ ] Address comments on code and resolve requested changes
- [ ] Merge own code

## Description
Issue: #443 

*Brief description of solution*
1. Fix the opacity by switching from percentages to decimals. The development version didn't have this issue for some reason. https://stackoverflow.com/questions/58853844/the-opacity-value-was-changed-to-1-after-building-the-reacjs-project
2. The ordering issue was caused by semantic-ui-react-datepickers styles that were duplicated in a `<style>` tag in the production build for some reason, overriding the CSS. Put a `div` selector before the class in the CSS to give it higher specificity.