### PR TITLE
437 datepicker same date click

### DIFF
--- a/web/src/components/map/menu.css
+++ b/web/src/components/map/menu.css
@@ -21,11 +21,13 @@ button.clndr-cell:hover {
 button.clndr-cell-disabled:disabled {
   background-color: white;
   color: black;
-  border-radius: 0;
 }
 
-/* include "button" selector to override above */
-button.clndr-cell-selected {
+/* include "button" and "disabled" selectors to override above. the
+ * currently selected date is disabled because otherwise it behaves
+ * unexpectedly when clicked (it clears the map).
+ */
+button.clndr-cell-selected:disabled {
   background-color: royalblue;
   color: white;
 }

--- a/web/src/components/map/menu.js
+++ b/web/src/components/map/menu.js
@@ -64,11 +64,11 @@ export const MapMenu = ({
         showToday={false}
         datePickerOnly={true}
         filterDate={(date) => {
-            date = moment(date).format("YYYY-MM-DD");
-            return date != mapDate.format("YYYY-MM-DD") &&
-            allDatesUnique.has(date);
-          }
-        }
+          date = moment(date).format("YYYY-MM-DD");
+          return (
+            date !== mapDate.format("YYYY-MM-DD") && allDatesUnique.has(date)
+          );
+        }}
       />
       <h3>Collection Details</h3>
       <List>

--- a/web/src/components/map/menu.js
+++ b/web/src/components/map/menu.js
@@ -60,10 +60,14 @@ export const MapMenu = ({
         format="YYYY-MM-DD"
         value={mapDate.toDate()}
         clearable={false}
+        clearOnSameDateClick={false}
         showToday={false}
         datePickerOnly={true}
-        filterDate={(date) =>
-          allDatesUnique.has(moment(date).format("YYYY-MM-DD"))
+        filterDate={(date) => {
+            date = moment(date).format("YYYY-MM-DD");
+            return date != mapDate.format("YYYY-MM-DD") &&
+            allDatesUnique.has(date);
+          }
         }
       />
       <h3>Collection Details</h3>

--- a/web/src/components/map/menu.test.js
+++ b/web/src/components/map/menu.test.js
@@ -123,13 +123,15 @@ describe("MapMenu", () => {
     expect(changeActiveCollection).toHaveBeenCalled();
   });
 
-  it("should change the collection date only when a date with data is clicked", () => {
+  it("should change the collection date only when another date with data is clicked", () => {
     const changeMapDate = jest.fn();
     renderMapMenu({ mapDate, allDatesUnique, changeMapDate });
     userEvent.click(screen.getByTestId("datepicker-input"));
     // the event is fired when the day changes- not when the datepicker is clicked.
     expect(changeMapDate).not.toHaveBeenCalled();
-    // the starting date should be July 17th, 2014
+    // the starting date should be July 17th, 2014. the currently selected date should be disabled
+    userEvent.click(screen.getByText("17"));
+    expect(changeMapDate).not.toHaveBeenCalled();
     // there is no data on the 18th and it should not conflict with other text values
     userEvent.click(screen.getByText("18"));
     expect(changeMapDate).not.toHaveBeenCalled();


### PR DESCRIPTION
## Checklist
- [x] Add description
- [x] Reference the open issue that the pull request addresses
- [x] Pass code quality checks
  - spin up docker `docker-compose up -d --build`
  - enter api container `docker-compose exec api /bin/bash`
  - run api tests `make validate`
  - exit container `ctrl/command+D` or `exit`
  - enter web container `docker-compose exec web /bin/sh`
  - run front-end tests `npm run test` or `npx jest`
  - lint `npm run lint-fix`
  - exit container as above
- [x] Request code review
  - Please allow **36 hours** from opening a pull request before merging a pull request- even if it has already received an approving review.
- [ ] Address comments on code and resolve requested changes
- [ ] Merge own code

## Description
Issue: #437 

*Brief description of solution*
* In the function that disables each date if it doesn't have data, also disable the currently selected date
* Fix style priorities by adding `:disabled` selector before styles for the currently selected date
* Test that clicking the currently selected date does nothing

Note: both this and the fix for 443 modify menu.css, so maybe we should finish and merge the first pull request first so that I can check that this one doesn't break.