### PR TITLE
Add state to track explicitly whether files match

### DIFF
--- a/web/src/components/upload/drop.js
+++ b/web/src/components/upload/drop.js
@@ -47,6 +47,7 @@ export const UploadDrop = ({
   proceedToConfirm,
 }) => {
   const [errorMessage, setErrorMessage] = useState("");
+  const [filesMatch, setFilesMatch] = useState(false);
   const { getRootProps, getInputProps } = useDropzone({
     onDrop: (acceptedFiles) => {
       setFiles([...files, ...acceptedFiles]);
@@ -63,6 +64,7 @@ export const UploadDrop = ({
    * @modifies {dustrakStart} dustrak start time is used for user feedback on confirmation page
    * @modifies {dustrakEnd} dustrak end time is used for user feedback on confirmation page
    * @modifies {dustrakSerial} dustrak serial is used for user feedback on confirmation page
+   * @modifies {filesMatch} if the end is reached with no errors, trigger the confirmation page effect
    */
   useEffect(() => {
     (async () => {
@@ -72,6 +74,7 @@ export const UploadDrop = ({
        * But the defualt values evaluate to falsy or invalid, to be handled by downstream logic
        * We can then always set state in the same order, with default or meaningful values
        */
+      setFilesMatch(false);
       let potentialMessage = "";
       let potentialDustrakStart = moment("");
       let potentialDustrakEnd = moment("");
@@ -110,6 +113,7 @@ export const UploadDrop = ({
               potentialDustrakStart = dustrakStart;
               potentialDustrakEnd = dustrakEnd;
               potentialDustrakSerial = getDustrakSerial(dustrakTextLines);
+              setFilesMatch(true);
             }
           }
         }
@@ -125,6 +129,7 @@ export const UploadDrop = ({
     setDustrakStart,
     setDustrakEnd,
     setDustrakSerial,
+    setFilesMatch,
   ]);
 
   /**
@@ -132,8 +137,8 @@ export const UploadDrop = ({
    * @modifies {prop} sets parent property of "phase" to value of "confirm"
    */
   useEffect(() => {
-    (files.length === 2) & !errorMessage && proceedToConfirm();
-  }, [files, errorMessage, proceedToConfirm]);
+    (files.length === 2) & filesMatch && proceedToConfirm();
+  }, [files, filesMatch, proceedToConfirm]);
 
   /**
    * Remove a file from the list by its index

--- a/web/src/components/upload/drop.test.js
+++ b/web/src/components/upload/drop.test.js
@@ -117,11 +117,11 @@ describe("Actions after extracting files", () => {
     expect(setFiles).toHaveBeenCalledWith([files[1], files[2]]);
   });
 
-  it("should proceed to the confirm page when there are two valid files", () => {
+  it("should proceed to the confirm page when there are two valid files", async () => {
     const files = [csvFileValid, logFile];
     const proceedToConfirm = jest.fn();
     renderUploadDrop({ files, proceedToConfirm });
-    expect(proceedToConfirm).toHaveBeenCalled();
+    await waitFor(() => expect(proceedToConfirm).toHaveBeenCalled());
   });
 });
 


### PR DESCRIPTION
## Checklist
- [x] Add description
- [x] Reference the open issue that the pull request addresses
- [x] Pass code quality checks
  - spin up docker `docker-compose up -d --build`
  - enter api container `docker-compose exec api /bin/bash`
  - run api tests `make validate`
  - exit container `ctrl/command+D` or `exit`
  - enter web container `docker-compose exec web /bin/sh`
  - run front-end tests `npm run test` or `npx jest`
  - lint `npm run lint-fix`
  - exit container as above
- [x] Request code review
  - Please allow **36 hours** from opening a pull request before merging a pull request- even if it has already received an approving review.
- [x] Address comments on code and resolve requested changes
- [x] Merge own code

## Description
Issue: #460 

*Brief description of solution*
* Find the bug: there was an effect that opened the confirmation page only if there was no error message, but the effect was triggered before the error message could be set
* Create a new state to track explicitly whether the files match, and use that state to determine whether to open the confirmation page
* Fix a failing test